### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140410_forward_all_requests_to_barium_and_show_api_error_in_cucumber_step_output'

### DIFF
--- a/kitchen/Rakefile
+++ b/kitchen/Rakefile
@@ -22,3 +22,25 @@ namespace :cloud do
     end
   end
 end
+
+namespace :dotoscrc do
+  desc 'Creates ~/.oscrc configuration file'
+  task :create, [:username, :password] do |t, args|
+    puts ENV.inspect
+    args = args.to_hash
+    if args.key?(:username) && args.key?(:password)
+      username = args[:username]
+      password = args[:password]
+
+      oscrc = File.open(File.join(ENV['HOME'], '.oscrc'), "w")
+      oscrc.puts '[https://api.suse.de]'
+      oscrc.puts "user=#{username}"
+      oscrc.puts "pass=#{password}"
+      oscrc.puts 'trusted_prj=SUSE:SLE-12:GA'
+      oscrc.close
+    else
+      puts "ERROR: Missing required paramters [:username, :password]"
+    end
+
+  end
+end


### PR DESCRIPTION
Please review the following changes:
- 620ba16 add rake task for .oscrc file
- 55ef09c unfortunatelly some calls takes longer than 15 seconds so increase to 30 seconds
- e386ce8 make rubocop happy
- 89fd20d Merge branch 'master' into review_140410_forward_all_requests_to_barium_and_show_api_error_in_cucumber_step_output
- 56899bd forward all requests to barium and show API error in cucumber step output
- a7d17e7 decrease aruba wait timeout
