### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140414_build_suseconnect_rpm_with_osc'

### DIFF
--- a/kitchen/cookbooks/connect/recipes/suse_connect.rb
+++ b/kitchen/cookbooks/connect/recipes/suse_connect.rb
@@ -2,16 +2,22 @@ git '/tmp/connect' do
   repository 'https://github.com/SUSE/connect.git'
   reference 'master'
   action 'sync'
+  user 'vagrant'
+  group 'users'
 end
 
 execute 'sudo bundle install' do
   command 'sudo bundle install'
   cwd node[:connect][:project]
+  user 'vagrant'
+  group 'users'
 end
 
 execute 'build SUSEConnect gem' do
   command 'gem build suse-connect.gemspec'
   cwd node[:connect][:project]
+  user 'vagrant'
+  group 'users'
 end
 
 # NOTE: Disabled because of RPM testing
@@ -23,30 +29,33 @@ end
 execute 'cp suse-connect-*.gem package/' do
   command 'cp suse-connect-*.gem package/'
   cwd node[:connect][:project]
+  user 'vagrant'
 end
 
 execute 'gem2rpm -l -o SUSEConnect.spec -t SUSEConnect.spec.erb suse-connect-*.gem' do
   command 'gem2rpm -l -o SUSEConnect.spec -t SUSEConnect.spec.erb suse-connect-*.gem'
   cwd "#{node[:connect][:project]}/package"
+  user 'vagrant'
 end
 
 execute 'create man page for SUSEConnect' do
   command 'ronn --roff --manual SUSEConnect --pipe ../README.md > SUSEConnect.1 && gzip SUSEConnect.1'
   not_if { ::File.exist?('/tmp/connect/package/SUSEConnect.1.gz') }
   cwd "#{node[:connect][:project]}/package"
+  user 'vagrant'
 end
 
 python_path = '$PYTHONPATH:/usr/lib64/python2.6/site-packages/'
-dir = '#{node[:connect][:project]}/package'
 osc_url = 'https://api.suse.de'
 osc_build = "osc -A #{osc_url} build #{node[:connect][:osc][:project]} #{node[:connect][:osc][:arch]} --no-verify"
 
 execute 'build SUSEConnect RPM' do
-  command "su vagrant -l -c 'cd #{dir} && export PYTHONPATH=#{python_path} && #{osc_build}'"
+  command "export PYTHONPATH=#{python_path}; #{osc_build}"
   cwd "#{node[:connect][:project]}/package"
 end
 
+zypper_options = '--non-interactive  --no-gpg-checks'
 execute 'install SUSEConnect RPM' do
-  command 'zypper in /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*'
+  command "zypper #{zypper_options} in /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*"
   cwd "#{node[:connect][:project]}/package"
 end

--- a/kitchen/cookbooks/connect/spec/suse_connect_spec.rb
+++ b/kitchen/cookbooks/connect/spec/suse_connect_spec.rb
@@ -37,14 +37,15 @@ describe 'connect::rubygems' do
     osc_build = 'osc -A https://api.suse.de build SLE_12 x86_64 --no-verify'
 
     expect(chef_run).to run_execute('build SUSEConnect RPM').with(
-      command: "su vagrant -l -c 'cd /tmp/connect/package && export PYTHONPATH=#{python_path} && #{osc_build}'",
+      command: "export PYTHONPATH=#{python_path}; #{osc_build}",
       cwd: '/tmp/connect/package'
     )
   end
 
   it 'installs SUSEConnect RPM' do
+    zypper_options = '--non-interactive  --no-gpg-checks'
     expect(chef_run).to run_execute('install SUSEConnect RPM').with(
-      command: 'zypper in /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*',
+      command: "zypper #{zypper_options} in /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*",
       cwd: '/tmp/connect/package'
     )
   end


### PR DESCRIPTION
Please review the following changes:
- cb2ad39 build SUSEConnect RPM as root
- b5a74ee make rubocop happy
- 4bbc97f install SUSEConnect RPM after building it
- 18ea446 store osc project and arch in defaults
- c929633 build SUSEConnect RPM with osc
- 891a472 install system gems
- 8a4be6e check whether package already installed before install it
- 89560ed remove zypper services in clean up section
- 2c78445 set project location in defaults
- 140e290 add general section to oscrc and SLE_12 to trsuted projects
- 6b8cb1c Merge pull request #36 from SUSE/review_140407_i18n_support
- 8be1745 Merge master
- ff8e6d3 Fix typo
- 6d9f572 Shorten line to 80chars
- 76d9352 Fix whitespace
- c5d0f00 Remove input sanitization test from spec
- bffccbf Remove redundant !nil check on assignments
- 50acb04 Remove pointless input well-formedness check
- 8f76296 whitespace
- 41a5b2e whitespace
- 6a23630 Set language via cli
- 7664996 Pass Client language to Connection
- 4d25b82 Store language option
- 4b8d22e Pass language option as Accept-Language header
