### PR TITLE
Catch zypper error exit status and raise exception

### DIFF
--- a/lib/suse/toolkit/system_calls.rb
+++ b/lib/suse/toolkit/system_calls.rb
@@ -2,6 +2,14 @@ module SUSE
   module Toolkit
     # Provides basic system calls interface
     module SystemCalls
+      class ErrorWithStatus < StandardError
+        attr_accessor :code
+
+        def initialize(code)
+          @code = code
+        end
+      end
+
       include Connect::Logger
 
       def call(command)
@@ -9,7 +17,11 @@ module SUSE
       end
 
       def call_with_output(command)
-        `#{command}`.chomp
+        output = `#{command}`.chomp
+        if $?
+          raise ErrorWithStatus.new($?.exitstatus) unless $?.success?
+        end
+        output
       end
 
     end


### PR DESCRIPTION
To know if there was a YaST lock we need to look for error code 7
(ZYPPER_EXIT_ZYPP_LOCKED) from zypper.  Next I need to add a DRY way to
handle the various exceptions possible in zypper.rb.
