### PR TITLE
ApiError - keep complete response

### DIFF
--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -31,7 +31,7 @@ module SUSE
         define_method name_for_method do |path, auth: nil, params: {} |
           @auth = auth
           response = json_request(name_for_method.downcase.to_sym, path, params)
-          raise(ApiError.new(response.code, response.body)) unless response.success
+          raise(ApiError, response) unless response.success
           response
         end
       end

--- a/lib/suse/connect/errors.rb
+++ b/lib/suse/connect/errors.rb
@@ -7,15 +7,23 @@ module SUSE
     class TokenNotPresent < StandardError; end
     class CannotDetectBaseProduct < StandardError; end
 
-    # Basic error for API interactions. Collects HTTP status codes and response body for future showing to
-    # user via {Cli}
+    # Basic error for API interactions. Collects HTTP response (which includes
+    # status code and response body) for future showing to user via {Cli}
     class ApiError < StandardError
-      attr_accessor :code, :body
+      attr_accessor :response
 
-      # @param code [Integer] the HTTP status code reported by API request
-      # @param body [Has]     reponse body parsed with JSON
-      def initialize(code, body)
-        @code, @body = code, body
+      # @param response [Net::HTTPResponse] the HTTP response error returned
+      # by API request
+      def initialize(response)
+        @response = response
+      end
+
+      def code
+        @response.code
+      end
+
+      def body
+        @response.body
       end
     end
 

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -22,7 +22,9 @@ describe SUSE::Connect::Cli do
 
     it 'should produce log output if ApiError encountered' do
       string_logger.should_receive(:error).with('ApiError with response: {:test=>1} Code: 222')
-      Client.any_instance.stub(:register!).and_raise ApiError.new(222, :test => 1)
+      response = Net::HTTPResponse.new('1.1', 222, 'Test')
+      expect(response).to receive(:body).and_return('{:test=>1}')
+      Client.any_instance.stub(:register!).and_raise ApiError.new(response)
       cli.execute!
     end
 


### PR DESCRIPTION
...for easier response type check by code like this:

``` ruby
rescue SUSE::Connect::ApiError => e
  case e.response
  when Net::HTTPClientError
    ...
  when Net::HTTPServerError
     ...
  end
end
```

It allows to use descriptive class names instead of number constants (`Net::HTTPNotFound` instead of `404`) or ranges (`Net::HTTPClientError` instead of `400..499`), the code is then more readable.
