### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140417_use_sles12_beta5_image_for_connect_testing'

### DIFF
--- a/kitchen/lib/cloud_vm.rb
+++ b/kitchen/lib/cloud_vm.rb
@@ -23,7 +23,7 @@ module Cloud
       end
 
       def create(name = 'SUSEConnect_testing')
-        image = connection.get_image('4f977f83-6e14-446a-b06c-db07aad7d051')
+        image = connection.get_image('19724f29-9713-4277-b359-2029508acf16')
         flavor = connection.get_flavor(2)
         address = connection.get_floating_ips.select {|ip| ip.instance_id.nil? }.first || connection.create_floating_ip
 


### PR DESCRIPTION
Please review the following changes:
- 8961fdf use sles12-beta5 image for connect testing
- 43d5069 Merge pull request #57 from SUSE/review_140414_update_package
- 2c6c728 Merge pull request #54 from SUSE/review_140414_distro_target
- 761c73f Revert "Catch zypper error exit status and raise exception"
- 2b8e66c Catch zypper error exit status and raise exception
- e7de30e Update package
- fde0104 allow to pass distro_target to announce_system
