### PR TITLE
Product - added "version", "arch" and "free" attributes

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -50,7 +50,7 @@ module SUSE
       def list_products(product_ident)
         result = @api.addons(basic_auth, product_ident).body
         result.map do |product|
-          SUSE::Connect::Product.new(product['name'], '', '', product['zypper_name'])
+          SUSE::Connect::Product.new(product)
         end
       end
 

--- a/lib/suse/connect/product.rb
+++ b/lib/suse/connect/product.rb
@@ -2,14 +2,17 @@
 # TODO: Maybe we should get rid of this class?
 class SUSE::Connect::Product # rubocop:disable Documentation
 
-  attr_reader :short_name, :long_name, :description, :product_ident
+  attr_reader :short_name, :long_name, :description, :product_ident, :version, :arch, :free
 
   # Constructor
-  def initialize(short_name, long_name, description, product_ident)
-    @short_name    = short_name
-    @long_name     = long_name
-    @description   = description
-    @product_ident = product_ident
+  def initialize(product)
+    @short_name    = product['name']
+    @long_name     = product['long_name']
+    @description   = product['description']
+    @product_ident = product['zypper_name']
+    @version = product['zypper_version']
+    @arch = product['arch']
+    @free = product['free']
   end
 
 end

--- a/spec/connect/product_spec.rb
+++ b/spec/connect/product_spec.rb
@@ -3,13 +3,16 @@ require 'spec_helper'
 describe SUSE::Connect::Product do
 
   subject do
-    extension_attrs = [
-      'SLEEK',
-      'SUSE LINUX ENTERPRISE EXTENSION KDE',
-      'SLEEK puts the modern yet familiar GUI back into SLE that you love',
-      'SLEEK-12'
-    ]
-    SUSE::Connect::Product.new(*extension_attrs)
+    extension = {
+      'name' => 'SLEEK',
+      'long_name' => 'SUSE LINUX ENTERPRISE EXTENSION KDE',
+      'description' => 'SLEEK puts the modern yet familiar GUI back into SLE that you love',
+      'zypper_name' => 'SLEEK-12',
+      'zypper_version' => '12',
+      'arch' => 'x86_64',
+      'free' => true
+    }
+    SUSE::Connect::Product.new(extension)
   end
 
   it 'has attribute short_name' do
@@ -26,6 +29,18 @@ describe SUSE::Connect::Product do
 
   it 'has attribute product_ident' do
     expect(subject.product_ident).not_to be_nil
+  end
+
+  it 'has attribute version' do
+    expect(subject.version).not_to be_nil
+  end
+
+  it 'has attribute arch' do
+    expect(subject.arch).not_to be_nil
+  end
+
+  it 'has attribute free' do
+    expect(subject.free).not_to be_nil
   end
 
 end


### PR DESCRIPTION
Changed parameters to a single `Hash` (`rubocop` complained about too much parameters).
