### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140602_send_suseconnect_package_version_in_user_agent_headersend_suseconnect_package_version_in_user_agent_header'

### DIFF
--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -47,6 +47,8 @@ module SUSE
         request['Content-Type']    = 'application/json'
         request['Accept']          = 'application/json,application/vnd.scc.suse.com.v1+json'
         request['Accept-Language'] = language
+        request['User-Agent']      = "SUSEConnect/#{SUSE::Connect::VERSION}"
+
         request.body               = params.to_json unless params.empty?
         response                   = @http.request(request)
         body                       = JSON.parse(response.body) if response.body

--- a/spec/connect/connection_spec.rb
+++ b/spec/connect/connection_spec.rb
@@ -164,6 +164,23 @@ describe SUSE::Connect::Connection do
       result.code.should eq 200
     end
 
+    it 'sends USER-AGENT header with SUSEConnect package version' do
+      headers = {
+        'Accept' => 'application/json,application/vnd.scc.suse.com.v1+json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'User-Agent' => "SUSEConnect/#{SUSE::Connect::VERSION}"
+      }
+
+      stub_request(:post, 'https://example.com/api/v1/test')
+        .with(headers: headers)
+        .to_return(:status => 200, :body => '', :headers => {})
+
+      connection = subject.new('https://example.com')
+      result = connection.post('/api/v1/test')
+      result.code.should eq 200
+    end
+
     it 'converts response into proper hash' do
 
       stub_request(:post, 'https://example.com/api/v1/test')


### PR DESCRIPTION
Please review the following changes:
- fe6af18 send SUSEConnect/package version in USER-AGENT header
- 6707ebe Merge pull request #90 from SUSE/review_140530_packaging_fixes
- 21ea381 include manpage files in specfile
- 5662486 Merge pull request #89 from SUSE/review_140528_align_package_md_with_rake_task_small_packaging_updates
- 307c28c Merge pull request #87 from SUSE/review_140528_ignore_root_vagrantfile_as_it_is_not_for_all
- 77ee160 align PACKAGE.md with rake task, small packaging updates
- ce468ba Merge pull request #88 from SUSE/review_140528_add_missing_package_changes
- 5435f81 Merge pull request #83 from SUSE/review_140527_srcrpm_generation
- 616955d Merge branch 'master' into review_140527_srcrpm_generation
- 0d13f15 Add missing package changes
- 6ba0448 Merge pull request #82 from SUSE/further_manpage_work
- e4f1fcc Merge branch 'master' into further_manpage_work
- 16d4c0f Merge pull request #85 from SUSE/review_140527_upgrade_product_support
- f76569c fix typo
- fef581a yast url
- 901fb7e point to yast code
- 9f356bc Merge branch 'master' into review_140527_upgrade_product_support
- 75f47d4 Ignore top level Vagrantfile
- 498c2aa fixes for rubocop
- 27bc406 add product_upgrade method for yast, update methods docs
- 951d4c3 adding upgrade product method to Connect::Client
- a17eed5 fix parameter name: it's product_id rigt now
- 43eeb77 Document 'insecure' option
- 02a171a Merge branch 'master' into review_140527_srcrpm_generation
- 56f2031 Fix src.rpm contents
- c327e73 Peg version of gem2rpm to fix src rpm generation
- 79df5a4 Merge branch 'master' into further_manpage_work
- b58105d Link to github
- 4b79a64 rewrite exit codes section
- 4adfdd3 use link relative links
- 6699912 index.txt must be in the same dir as the source folders
- 31ea01b rename man sources
- 4c27a8a Flesh out the SUSEConnect(5) manpage
- 0b3596c Bump version
- 6aacc1d First cut of config file manpage
- 66d20c6 Adapt tests to different log level
- 05dacb9 Update .gitignore
- 17cf246 Document error codes
- 20f7014 Reorder error codes to match layering
- 72c6a68 Make CLI error codes distinct
- 93b90d9 Add SMT, ENVIRONMENT and IMPLEMENTATION man sects
- 29b8ef6 Put the manpage in section 8 where it belongs
