### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140630_extend_yast_wrapper_to_include_activated_'

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -116,7 +116,7 @@ module SUSE
       private
 
       def announce_if_not_yet
-        unless System.announced?
+        unless System.credentials?
           login, password = announce_system(nil, @options[:instance_data_file])
           Credentials.new(login, password, Credentials.system_credentials_file).write
         end

--- a/lib/suse/connect/system.rb
+++ b/lib/suse/connect/system.rb
@@ -40,17 +40,17 @@ module SUSE
           end
         end
 
-        def announced?
+        def credentials?
           !!credentials
         end
 
         # Checks if system activations includes base product
         def activated_base_product?
-          announced? && Status.activated_products.include?(Zypper.base_product)
+          credentials? && Status.activated_products.include?(Zypper.base_product)
         end
 
         def remove_credentials
-          File.delete Credentials.system_credentials_file if announced?
+          File.delete Credentials.system_credentials_file if credentials?
         end
 
         def add_service(service)

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -65,7 +65,7 @@ module SUSE
         #
         # @return Boolean
         def product_activated?(product)
-          if SUSE::Connect::System.announced?
+          if SUSE::Connect::System.credentials?
             SUSE::Connect::Status.activated_products.include?(product)
           end
         end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -232,32 +232,32 @@ describe SUSE::Connect::Client do
     end
 
     it 'should call announce if system not registered' do
-      System.stub(:announced? => false)
+      System.stub(:credentials? => false)
       subject.should_receive(:announce_system)
       subject.register!
     end
 
     it 'should not call announce on api if system registered' do
-      System.stub(:announced? => true)
+      System.stub(:credentials? => true)
       subject.should_not_receive(:announce_system)
       subject.register!
     end
 
     it 'should call activate_product on api' do
-      System.stub(:announced? => true)
+      System.stub(:credentials? => true)
       subject.should_receive(:activate_product)
       subject.register!
     end
 
     it 'writes credentials file' do
-      System.stub(:announced? => false)
+      System.stub(:credentials? => false)
       subject.stub(:announce_system => %w{ lg pw })
       Credentials.should_receive(:new).with('lg', 'pw', Credentials::GLOBAL_CREDENTIALS_FILE).and_call_original
       subject.register!
     end
 
     it 'adds service after product activation' do
-      System.stub(:announced? => true)
+      System.stub(:credentials? => true)
       System.should_receive(:add_service)
       subject.register!
     end

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -84,7 +84,7 @@ describe SUSE::Connect::System do
     context :remove_credentials do
 
       before(:each) do
-        subject.should_receive(:announced?).and_return(true)
+        subject.should_receive(:credentials?).and_return(true)
         File.should_receive(:delete).with(credentials_file).and_return(true)
       end
 
@@ -95,35 +95,35 @@ describe SUSE::Connect::System do
     end
   end
 
-  describe '.announced?' do
+  describe '.credentials?' do
 
-    it 'returns false if credentials are nil' do
-      subject.stub(:credentials => nil)
-      subject.announced?.should be false
+    it 'returns false if no credentials' do
+      subject.stub(credentials: nil)
+      subject.credentials?.should be false
     end
 
-    it 'returns true if credentials exist and username is prefixed with SCC_' do
-      subject.stub(:credentials => Credentials.new('SCC_John', 'B'))
-      subject.announced?.should be true
+    it 'returns true if credentials exist' do
+      subject.stub(credentials: Credentials.new('123456789', 'ABCDEF'))
+      subject.credentials?.should be true
     end
   end
 
   describe '.activated_base_product?' do
 
-    it 'returns false if sytem is not announced' do
-      subject.stub(:announced? => false)
+    it 'returns false if sytem does not have a credentials' do
+      subject.stub(:credentials? => false)
       subject.activated_base_product?.should be false
     end
 
-    it 'returns false if sytem is announced but not activated' do
-      subject.stub(announced?: true)
+    it 'returns false if sytem has credentials but not activated' do
+      subject.stub(credentials?: true)
       Zypper.stub(:base_product)
       expect(SUSE::Connect::Status).to receive(:activated_products).and_return([])
       subject.activated_base_product?.should be false
     end
 
-    it 'returns true if sytem is announced and activated' do
-      subject.stub(announced?: true)
+    it 'returns true if sytem has credentials and activated' do
+      subject.stub(credentials?: true)
       product = Zypper::Product.new name: 'OpenSUSE'
 
       expect(Zypper).to receive(:base_product).and_return(product)

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -130,13 +130,13 @@ describe SUSE::Connect::YaST do
   describe '#product_activated?' do
     let(:product) { Remote::Product.new(identifier: 'tango') }
 
-    it 'returns false if system is not announced' do
-      expect(System).to receive(:announced?).and_return(false)
+    it 'returns false if no credentials' do
+      expect(System).to receive(:credentials?).and_return(false)
       subject.product_activated? product
     end
 
     it 'checks if the given product is already activated in SCC' do
-      expect(System).to receive(:announced?).and_return(true)
+      expect(System).to receive(:credentials?).and_return(true)
       expect(Status).to receive(:activated_products).and_return([product])
       subject.product_activated? product
     end


### PR DESCRIPTION
Please review the following changes:
- 284bb3c Merge pull request #124 from SUSE/review_140630_fix_status_call_regression
- 42df4ae add product_activated? and system_activated? methods to the YAST wrapper class
- 0d4c87b introduce activated? and adapt registered? method
- 1bef3ed rename registered? to announced?
- 509b9d5 Update package files
- 2202147 Fix status call regression in case of free products
