### PR TITLE
allow to pass client_params to YaST status call

### DIFF
--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -63,6 +63,7 @@ module SUSE
         # Gets the list from SCC and returns them.
         #
         # @param product [Remote::Product] product to list extensions for
+        # @param [Hash] client_params parameters to instantiate {Client}
         #
         # @return [Product] {Product}s from registration server with all extensions included
         def show_product(product, client_params = {})
@@ -71,12 +72,12 @@ module SUSE
 
         # Checks if the given product is already activated in SCC
         # @param product [Remote::Product] product
+        # @param [Hash] client_params parameters to instantiate {Client}
         #
         # @return Boolean
-        def product_activated?(product)
-          if SUSE::Connect::System.credentials?
-            SUSE::Connect::Status.activated_products.include?(product)
-          end
+        def product_activated?(product, client_params = {})
+          return false unless SUSE::Connect::System.credentials?
+          status(client_params).activated_products.include?(product)
         end
 
         # Writes the config file with the given parameters, overwriting any existing contents

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -143,14 +143,25 @@ describe SUSE::Connect::YaST do
 
     it 'returns false if no credentials' do
       expect(System).to receive(:credentials?).and_return(false)
-      subject.product_activated? product
+      expect(subject.product_activated?(product)).to be_false
     end
 
     it 'checks if the given product is already activated in SCC' do
       expect(System).to receive(:credentials?).and_return(true)
       expect(Status).to receive(:activated_products).and_return([product])
-      subject.product_activated? product
+      expect(subject.product_activated?(product)).to be_true
     end
+
+    it 'allows to pass a Hash with params to instantiate the client' do
+      expect(System).to receive(:credentials?).and_return(true)
+      client = double 'status'
+      params_hash = { foo: 'bar' }
+      expect(Client).to receive(:new).with(params_hash).and_return(client)
+      expect(Status).to receive(:client=).with(client)
+      expect(Status).to receive(:activated_products).and_return([product])
+      expect(subject.product_activated?(product, params_hash)).to be_true
+    end
+
   end
 
   describe '#write_config' do


### PR DESCRIPTION
https://trello.com/c/qeynxOUK/2073-cnt-yast-wants-that-product-activated-call-in-yast-wrapper-to-accept-client-parameter-hash   
