### PR TITLE
update_system should be able to send all the data as at announce_system ...

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -51,11 +51,13 @@ module SUSE
       #   In this case we expect Base64 encoded string with login and password
       # @return [OpenStruct] responding to #body(response from SCC), #code(natural HTTP response code) and #success.
       #
-      def update_system(auth)
+      def update_system(auth, distro_target = nil, instance_data = nil)
         payload = {
           :hostname      => System.hostname,
-          :hwinfo        => System.hwinfo
+          :hwinfo        => System.hwinfo,
+          :distro_target => distro_target || Zypper.distro_target
         }
+        payload[:instance_data] = instance_data if instance_data
         @connection.put('/connect/systems', :auth => auth, :params => payload)
       end
 


### PR DESCRIPTION
update_system should change values which were provided during announce_system.
So it makes sense to allow the update of all the values provided via announce_system.

Including now distro_target and instance_data.

distro_target is required to fix Bug 889778
