### PR TITLE
Fix for bnc #890881

### DIFF
--- a/lib/suse/connect/hwinfo/x86.rb
+++ b/lib/suse/connect/hwinfo/x86.rb
@@ -37,7 +37,11 @@ class SUSE::Connect::HwInfo::X86 < SUSE::Connect::HwInfo::Base
 
     # Simple arch abstraction - as means to determine uuid can vary.
     def x86_64_uuid
-      uuid_output = execute('dmidecode -s system-uuid', false)
+      if File.file?('/sys/hypervisor/uuid')
+        uuid_output = IO.read('/sys/hypervisor/uuid')
+      else
+        uuid_output = execute('dmidecode -s system-uuid', false)
+      end
       uuid_output == 'Not Settable' ? nil : uuid_output
     end
 


### PR DESCRIPTION
- Read the uuid generated by the hypervisor if it exists
- On paravirtual Xen guests there is no dmi information, thus dmidecode
  fails. Instead a UUID is generated by the hypervisor and made available
  in /sys/hypervisor/uuid use this value for registration.
  - This allows us to register guests running in EC2 and
    addresses bnc #890881
