### PR TITLE
[Review] Request from 'wstephenson' @ 'SUSE/connect/review_140813_increase_test_timeouts_for_registration'

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,6 @@ require 'aruba/cucumber'
 require 'cucumber/rspec/doubles'
 
 Before('@slow_process') do
-  @aruba_io_wait_seconds = 30
-  @aruba_timeout_seconds = 30
+  @aruba_io_wait_seconds = 90
+  @aruba_timeout_seconds = 90
 end


### PR DESCRIPTION
Please review the following changes:
- 160f0b9 timeout from 30 to 90 seconds
- 557626c Merge pull request #159 from SUSE/xenUUID
- 6311255 update osc files
- d49f8f5 update SUSEConnect.changes
- f2e44af bump version
- 048c7e1 add test case for uuid extraction on paravirtual Xen guests there no dmi information available
- a99e63f add INFO comment and remove new line at the end of uuid string
- 993b108 update osc files
- 174eaa8 - Read the uuid generated by the hypervisor if it exists   + On paravirtual Xen guests there is no dmi information, thus dmidecode     fails. Instead a UUID is generated by the hypervisor and made available     in /sys/hypervisor/uuid use this value for registration.   + This allows us to register guests running in EC2 and     addresses bnc #890881
