### PR TITLE
[Review] Request from 'digitaltom' @ 'SUSE/connect/review_140905_allow_to_set_distro_target_on_update_system_call_2183'

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -51,13 +51,12 @@ module SUSE
       #   In this case we expect Base64 encoded string with login and password
       # @return [OpenStruct] responding to #body(response from SCC), #code(natural HTTP response code) and #success.
       #
-      def update_system(auth, distro_target = nil, instance_data = nil)
+      def update_system(auth, distro_target = nil)
         payload = {
           :hostname      => System.hostname,
           :hwinfo        => System.hwinfo,
           :distro_target => distro_target || Zypper.distro_target
         }
-        payload[:instance_data] = instance_data if instance_data
         @connection.put('/connect/systems', :auth => auth, :params => payload)
       end
 

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -68,8 +68,8 @@ module SUSE
 
       # Re-send the system's hardware details on SCC
       #
-      def update_system
-        @api.update_system(system_auth)
+      def update_system(distro_target = nil)
+        @api.update_system(system_auth, distro_target)
       end
 
       # Activate a product

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -25,8 +25,8 @@ module SUSE
         # @param [String] distro_target desired distro target
         #
         # @return [Array <String>] SCC / system credentials - login and password tuple
-        def update_system(client_params = {})
-          Client.new(client_params).update_system
+        def update_system(client_params = {}, distro_target = nil)
+          Client.new(client_params).update_system(distro_target)
         end
 
         # Activates a product on SCC / the registration server.

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -304,12 +304,14 @@ describe SUSE::Connect::Api do
       stub_update_call
       System.stub(:hostname => 'connect')
       System.stub(:hwinfo => 'hwinfo')
+      Zypper.stub(:distro_target => 'openSUSE-4.1-x86_64')
     end
 
     it 'is authenticated via basic auth' do
       payload = [
         '/connect/systems',
-        :auth => 'Basic: encodedgibberish', :params => { :hostname => 'connect', :hwinfo => 'hwinfo' }
+        :auth => 'Basic: encodedgibberish', :params => { :hostname => 'connect', :hwinfo => 'hwinfo',
+                                                         :distro_target => 'openSUSE-4.1-x86_64' }
       ]
       Connection.any_instance.should_receive(:put).with(*payload).and_call_original
       subject.new(client).update_system('Basic: encodedgibberish')

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -144,8 +144,13 @@ describe SUSE::Connect::Client do
         end
 
         it 'calls underlying api' do
-          Api.any_instance.should_receive(:update_system).with('auth')
+          Api.any_instance.should_receive(:update_system).with('auth', nil)
           subject.update_system
+        end
+
+        it 'forwards distro_target to api' do
+          Api.any_instance.should_receive(:update_system).with('auth', 'my-distro-target')
+          subject.update_system('my-distro-target')
         end
 
       end

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -42,6 +42,16 @@ describe SUSE::Connect::YaST do
       subject.update_system
     end
 
+    it 'forwards distro_target parameter to client' do
+      Client.any_instance.should_receive(:update_system).with('my-distro-target')
+      subject.update_system({}, 'my-distro-target')
+    end
+
+    it 'uses client params' do
+      Client.should_receive(:new).with(:language => 'de').and_call_original
+      subject.update_system(:language => 'de')
+    end
+
   end
 
   describe '#activate_product' do


### PR DESCRIPTION
Please review the following changes:
- c8cf8be allow to set distro_target durin update_system call
- 44c2ea4 update_system should be able to send all the data as at announce_system (bnc#889778)
