### PR TITLE
Specify the size of instance we need exactly

### DIFF
--- a/kitchen/Vagrantfile
+++ b/kitchen/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure('2') do |config|
       os.api_key      = ENV['CLOUD_PASS']
 
       os.tenant = 'appliances'
-      os.flavor       = /m1.small/
+      os.flavor       = 'm1.small'
       os.image        = /scc-connect-testing-sles-rc1/
       os.networks     = ['fixed']
       os.floating_ip  = 'auto'


### PR DESCRIPTION
/m1.small/ also matched (because regexp) /m1.smaller/ which was too small
for our needs. Using a string specifies exactly which instance size to
use.
