### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_140917_fix_vagrant_failure_for_suseconnect_integration_testing'

### DIFF
--- a/kitchen/Vagrantfile
+++ b/kitchen/Vagrantfile
@@ -20,9 +20,10 @@ Vagrant.configure('2') do |config|
       os.username     = ENV['CLOUD_USER']
       os.api_key      = ENV['CLOUD_PASS']
 
-      os.tenant = 'appliances'
-      os.flavor       = /m1.small/
-      os.image        = /scc-connect-testing-sles-rc1/
+      os.tenant       = 'appliances'
+      os.flavor       = /d2.small/
+
+      os.image        = /scc-connect-testing-sles-rc3/
       os.networks     = ['fixed']
       os.floating_ip  = 'auto'
 


### PR DESCRIPTION
Please review the following changes:
- 1ae8bdb fix vagrant failure for SUSEConnect integration testing
- 30f6311 Merge pull request #174 from SUSE/review_140915_fix_failing_ci_tests_2193
- 32504f9 Improve feature step names in response to feedback
- 61b769a Update packaging
- b01719a Clean comments
- 05d0a40 Fully qualify class name
- e219a8d block not method call
- 758bdb9 Clean up by removing local credentials after test
- c147403 Match error message
- 3700ccf Deregister on SCC only
- ae103a4 Remove tag locking libzypp
- 914762e Merge pull request #173 from SUSE/review_140910_fix_cloud_integration_testing_2188
- bbfa18d Add RC3 veewee definition
- b5e4dde Use rc3 image
- 94ea836 Merge pull request #172 from SUSE/review_140910_fix_cloud_integration_testing_2188
- 3bdf3f6 Specify the size of instance we need exactly
- 7fa6e1d Merge pull request #171 from SUSE/review_140908_error_on_stale_credentials_2156
- 511f7a1 Split long line
- 5c36751 Add unit test for 401
- dddd4d6 Implement review suggestions
- d22be46 Useful error message on 401
- 4fc8eba Integration test
- 9b06b2f Merge pull request #170 from SUSE/review_140905_add_support_for_instance_data_in_update_system
- 608b84b Merge pull request #169 from SUSE/review_140905_version_bump_for_rc3
- f485ec6 add read_file method, add support for instance data file in update_system
- 0821701 Merge branch 'master' into review_140905_version_bump_for_rc3
- 4d83ee4 Update changelog
- 6c3536d Update package version
- 0502a60 Merge branch 'master' of github.com:SUSE/connect
- d46c203 Merge pull request #168 from SUSE/review_140905_write_config
- 9e3ac72 add test for CLI with --write-config
- 56f3efc introduce --write-config
- 0093a8b adjust feature syntax
- 582f6a1 Merge pull request #167 from SUSE/review_140905_allow_to_set_distro_target_on_update_system_call_2183
- c8cf8be allow to set distro_target durin update_system call
- 44c2ea4 update_system should be able to send all the data as at announce_system (bnc#889778)
- b306b3d Merge pull request #166 from SUSE/review_140904_use_requires_instead_of_prereq
- 83abce9 Update package version
- 6d1b561 use requires instead of prereq
- f702930 Merge pull request #165 from SUSE/review_140904_fix_integration_test_extension_repo_name
- 6328744 Merge branch 'master' into review_140904_fix_integration_test_extension_repo_name
- 8789830 Change capitalisation of test case to repodata
- 2f42ed3 Merge pull request #164 from SUSE/review_140904_use_v3_api
- 80ba772 Remove spurious newline
- 5994a20 Emulate current SCC json interface
- e2338b2 Specify v3 api
- b740871 Merge pull request #163 from SUSE/review_140819_fix_featuretest_cli_option_parsing
- e8ac328 Update packaging
- 30f87e4 Boy scout: more ambiguous context/describe symbols
- 9ec9a40 Boy scout work: resolve rspec3 ambiguous symbol warnings
- 894b67c Boy scout work: fix deprecation warnings
- 50fb28b Revert to testing master for pull request
- 1361b1f Use this branch for testing itself
- 5cdf983 Handle --status option to connect
- 4753320 Add dummy 2nd argument to --status for parser
- c269a35 Merge pull request #162 from SUSE/review_140721_handle_zypper_nonzero_returns
- bf476bc Move outside if statement, to protect else clause
- 13c3327 Rubocop fixes
- 80904e7 Merge branch 'master' into review_140721_handle_zypper_nonzero_returns
- a7835cf Revert recipe to test master
- 239dd15 Move zypper test back to correct place
- 5f9d527 Remove pending zypper unit test
- 7b48795 Increase coverage
- 270474b Remove cmd from error logging; logged previously
- 898ee35 Merge pull request #161 from SUSE/review_140813_small_connect_improvements_that_came_out_of_card_2149
- 38e3a95 test FileError
- 4cf2d50 use file error
- c10fe4d use log.fatal instead of puts
- 290906a improve test for instance data not found
- 2d5a909 use class instance var
- aeca6ee test for non existing instance data file
- 306c7e7 fix architecture caching in tests
- 6919cc6 Move zypper specific error handling into the zypper case, and report composite error
- 9f0910e Another attempt to lock git reliably
- 318b9a3 Merge remote-tracking branch 'origin/master' into review_140813_small_connect_improvements_that_came_out_of_card_2149
- e112cb8 See if the previous successful registration prevents zypper from failing as expected
- c2e7817 Capture zypper output and report on error
- 2f0a2d2 Don't put the cucumber process to sleep
- 2f20e06 Make zypp locking clean
- 58d5da7 Log zypper errors and exit with zypper return code
- ce9c279 Include exit status in zypper error
- 8c42640 typo
- 1a54ba7 test added in wrong place
- 31404f5 Merge branch 'master' into review_140721_handle_zypper_nonzero_returns
- 5ade0ae Merge branch 'master' into review_140721_handle_zypper_nonzero_returns
- 1b9d2b7 Merge pull request #160 from SUSE/review_140813_increase_test_timeouts_for_registration
- 9de507a cache output of 'uname -i' as it certainly won't change during the run of SUSEconnect
- 2b7f027 improve error message when instancedata not found
- d481c34 correctly catch invalid cmd options, fix error exit codes
- 4afc01d wrong lockfile path
- ff13351 Use this branch for testing
- 2c7ecf8 Move hooks to env and test to integration
- 160f0b9 timeout from 30 to 90 seconds
- 3b9689f First stab at locking/unlocking libzypp in tests
- 28d7f6b Merge branch 'master' into review_140721_handle_zypper_nonzero_returns
- 077a648 Test for locked zypper
