### PR TITLE
[Review] Request from 'kirushik' @ 'SUSE/connect/review_141013_comment_for_the_obscure_hostname_logic'

### DIFF
--- a/lib/suse/connect/system.rb
+++ b/lib/suse/connect/system.rb
@@ -55,6 +55,7 @@ module SUSE
             hostname
           else
             # Fix for bnc#889869
+            # Sending (and storing on our servers) the public IPs would be a privacy violation
             addr_info = Socket.ip_address_list.find {|intf| intf.ipv4_private? }
             addr_info.ip_address if addr_info
           end


### PR DESCRIPTION
Please review the following changes:
- 15e7e61 Commented the not-so-clear hostname generation logic
- 862c1b0 Merge pull request #180 from SUSE/review_141006_config_refactoring
- 68b3e6d Fix test to expect call on SUSE::Connect::Config rather than on RbConfig
- 4598515 Fix feedback from pr#180
- 43e0c82 Fix Style issues
- b2a3b05 Use attr accessor with @ sign
- ffc9bfe Refactor config logic to push configuration logic to one predefined object
