### PR TITLE
Compute distro_target from the -p option for rooted environment.

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -174,7 +174,9 @@ module SUSE
         if registered?
           update_system
         else
-          login, password = announce_system(nil, @config.instance_data_file)
+          distro_target = @config.product ? @config.product.distro_target : nil
+          login, password = announce_system(distro_target,
+                                            @config.instance_data_file)
           Credentials.new(login, password, Credentials.system_credentials_file).write
         end
       end

--- a/lib/suse/connect/remote/product.rb
+++ b/lib/suse/connect/remote/product.rb
@@ -23,4 +23,11 @@ class SUSE::Connect::Remote::Product < SUSE::Connect::Remote::ServerDrivenModel
       release_type: release_type
     }
   end
+
+  def distro_target
+    version = self.version.scan(/\d+/)[0]
+    identifier = self.identifier.downcase
+    identifier = 'sle' if (identifier =~ /^sle/)
+    "#{identifier}-#{version}-#{arch}"
+  end
 end

--- a/spec/connect/remote/product_spec.rb
+++ b/spec/connect/remote/product_spec.rb
@@ -42,6 +42,12 @@ describe SUSE::Connect::Remote::Product do
     end
   end
 
+  describe '#distro_target' do
+    it 'generate distro target' do
+      expect(subject.distro_target).to eq 'sle-12-x86_64'
+    end
+  end
+
   it_behaves_like 'server driven model'
 
   describe '#==' do


### PR DESCRIPTION
**Problem:**
SMT requires a distro_target for the /connect/subscriptions/systems
post request. This value is usually fetched from
/etc/products.d/baseproduct, but that file doesn't exist when
registering to create a rootfs from scratch.

**Solution:**
This commit tries hard to compute a distro_target value from the
product.
