### PR TITLE
Yast version can be set and is added to user-agent header if present

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -25,6 +25,7 @@ module SUSE
           :verify_callback => client.config.verify_callback,
           :debug           => client.config.debug
         )
+        @connection.yast_version = client.config.yast_version
       end
 
       # Announce a system to SCC.

--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -16,7 +16,7 @@ module SUSE
         :delete => Net::HTTP::Delete
       }
 
-      attr_accessor :debug, :http, :auth, :language
+      attr_accessor :debug, :http, :auth, :language, :yast_version
 
       def initialize(endpoint, language: nil, insecure: false, debug: false, verify_callback: nil)
         uri              = URI.parse(endpoint)
@@ -76,6 +76,11 @@ module SUSE
         # no gzip compression for easier debugging
         request['Accept-Encoding'] = 'identity' if debug
         request['User-Agent']      = "SUSEConnect/#{SUSE::Connect::VERSION}"
+
+        unless @yast_version.nil?
+          request['User-Agent'] += ";YAST/#{yast_version}"
+        end
+
       end
 
       # set a verify_callback to HTTP object, use a custom callback

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -11,7 +11,8 @@ describe SUSE::Connect::Api do
            insecure: false,
            verify_callback: nil,
            debug: false,
-           token: 'token-shmocken'
+           token: 'token-shmocken',
+           yast_version: nil
     )
   end
 

--- a/spec/connect/connection_spec.rb
+++ b/spec/connect/connection_spec.rb
@@ -198,6 +198,25 @@ describe SUSE::Connect::Connection do
       result.code.should eq 200
     end
 
+    it 'sends USER-AGENT header with SUSEConnect package version and YAST version' do
+      headers = {
+        'Accept' => api_header_version,
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'User-Agent' => "SUSEConnect/#{SUSE::Connect::VERSION};YAST/1.2.3"
+      }
+
+      stub_request(:post, 'https://example.com/api/v1/test')
+          .with(headers: headers)
+          .to_return(:status => 200, :body => '', :headers => {})
+
+      connection = subject.new('https://example.com')
+      connection.yast_version = '1.2.3'
+      result = connection.post('/api/v1/test')
+
+      result.code.should eq 200
+    end
+
     it 'converts response into proper hash' do
 
       stub_request(:post, 'https://example.com/api/v1/test')


### PR DESCRIPTION
Make it possible for YAST to add its version to SUSE connect's user-agent header.