### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150508__5_connect_suseconnect_should_support_de_registration_2591'

### DIFF
--- a/features/integration.feature
+++ b/features/integration.feature
@@ -52,6 +52,8 @@ Feature: SUSEConnect full stack integration testing
   Scenario: System de-registration
     When I cleanly deregister the system removing local credentials
     Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
 
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -80,3 +80,5 @@ Feature: SUSEConnect full stack integration testing
     Provided registration code is not recognized by registration server.
     """
 
+  Scenario: Remove all registration leftovers
+    When System cleanup

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -51,9 +51,15 @@ Feature: SUSEConnect full stack integration testing
   Scenario: System de-registration
     When I cleanly deregister the system removing local credentials
     Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
+
     And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
     And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
     And a file named "/etc/zypp/credentials.d/Web_and_Scripting_Module_12_x86_64" should not exist
+
+    And I run `zypper lr`
+    And the output should not contain "SUSE_Linux_Enterprise_Server_12_x86_64"
+    And the output should not contain "SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64"
+    And the output should not contain "Web_and_Scripting_Module_12_x86_64"
 
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -48,13 +48,6 @@ Feature: SUSEConnect full stack integration testing
   Scenario: API version check
     When SUSEConnect library should respect API headers
 
-  # De-register the system at the end of the feature
-  Scenario: System de-registration
-    When I cleanly deregister the system removing local credentials
-    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
-    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
-    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
-
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments
     Then I deregister the system only
@@ -73,5 +66,13 @@ Feature: SUSEConnect full stack integration testing
     """
     Provided registration code is not recognized by registration server.
     """
+
+  # IMPORTANT NOTICE: Call de-register the system at the end of the feature file
+  Scenario: System de-registration
+    When I cleanly deregister the system removing local credentials
+    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
+    And a file named "/etc/zypp/credentials.d/Web_and_Scripting_Module_12_x86_64" should not exist
 
 

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -48,6 +48,13 @@ Feature: SUSEConnect full stack integration testing
   Scenario: API version check
     When SUSEConnect library should respect API headers
 
+  Scenario: System de-registration
+    When I cleanly deregister the system removing local credentials
+    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
+    And a file named "/etc/zypp/credentials.d/Web_and_Scripting_Module_12_x86_64" should not exist
+
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments
     Then I deregister the system only
@@ -66,13 +73,4 @@ Feature: SUSEConnect full stack integration testing
     """
     Provided registration code is not recognized by registration server.
     """
-
-  # IMPORTANT NOTICE: Call de-register the system at the end of the feature file
-  Scenario: System de-registration
-    When I cleanly deregister the system removing local credentials
-    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
-    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
-    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64" should not exist
-    And a file named "/etc/zypp/credentials.d/Web_and_Scripting_Module_12_x86_64" should not exist
-
 

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -129,4 +129,5 @@ Then(/^System cleanup$/) do
 
   FileUtils.rm_rf(Dir.glob('/etc/zypp/credentials.d/*'))
   FileUtils.rm_rf(Dir.glob('/etc/zypp/services.d/*'))
+  FileUtils.rm_rf(Dir.glob('/etc/zypp/repos.d/*'))
 end

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -109,14 +109,16 @@ Then(/^SUSEConnect library should be able to retrieve the product information$/)
   products.each {|product| puts "- #{product}" }
 
   extensions = [
+    'Advanced Systems Management Module 12 x86_64',
+    'Legacy Module 12 x86_64',
+    'Public Cloud Module 12 x86_64',
+    'SUSE Cloud for SLE 12 Compute Nodes 5 x86_64',
+    'SUSE Enterprise Storage 1 x86_64',
     'SUSE Linux Enterprise High Availability Extension 12 x86_64',
+    'SUSE Linux Enterprise Live Patching 12 x86_64',
     'SUSE Linux Enterprise Software Development Kit 12 x86_64',
     'SUSE Linux Enterprise Workstation Extension 12 x86_64',
-    'SUSE Linux Enterprise Live Patching 12 x86_64',
-    'Advanced Systems Management Module 12 x86_64',
-    'Web and Scripting Module 12 x86_64',
-    'Public Cloud Module 12 x86_64',
-    'Legacy Module 12 x86_64'
+    'Web and Scripting Module 12 x86_64'
   ]
 
   expect(products).to match_array(extensions)

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -127,6 +127,6 @@ end
 Then(/^System cleanup$/) do
   require 'fileutils'
 
-  FileUtils.rm_rf('/etc/zypp/credentials.d/*')
-  FileUtils.rm_rf('/etc/zypp/services.d/*')
+  FileUtils.rm_rf(Dir.glob('/etc/zypp/credentials.d/*'))
+  FileUtils.rm_rf(Dir.glob('/etc/zypp/services.d/*'))
 end

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -123,3 +123,10 @@ Then(/^SUSEConnect library should be able to retrieve the product information$/)
 
   expect(products).to match_array(extensions)
 end
+
+Then(/^System cleanup$/) do
+  require 'fileutils'
+
+  FileUtils.rm_rf('/etc/zypp/credentials.d/*')
+  FileUtils.rm_rf('/etc/zypp/services.d/*')
+end

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -107,6 +107,10 @@ module SUSE
           @options[:token] = opt
         end
 
+        @opts.on('-d', '--de-register', 'de-register my system in order to not consume a subscription in SCC anymore') do |opt|
+          @options[:deregister] = true
+        end
+
         @opts.on('--instance-data  [path to file]', 'Path to the XML file holding the public key and instance data',
                  '  for cloud registration with SMT') do |opt|
           check_if_param(opt, 'Please provide the path to your instance data file')

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -109,8 +109,8 @@ module SUSE
           @options[:token] = opt
         end
 
-        @opts.on('-d', '--de-register', 'de-registers a system in order to not consume a subscription in SCC anymore,',
-                 ' and removes all installed services') do |opt|
+        @opts.on('-d', '--de-register', 'De-registers a system in order to not consume a subscription slot in SCC anymore',
+                 ' and removes all services installed by SUSEConnect') do |opt|
           @options[:deregister] = true
         end
 

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -22,6 +22,8 @@ module SUSE
           Status.new(@config).print_product_statuses(:json)
         elsif @config.status_text
           Status.new(@config).print_product_statuses(:text)
+        elsif @config.deregister
+          Client.new(@config).deregister!
         else
           if @config.instance_data_file && @config.url_default?
             log.error 'Please use --instance-data only in combination with --url pointing to your SMT server'
@@ -107,7 +109,8 @@ module SUSE
           @options[:token] = opt
         end
 
-        @opts.on('-d', '--de-register', 'de-register my system in order to not consume a subscription in SCC anymore') do |opt|
+        @opts.on('-d', '--de-register', 'de-registers a system in order to not consume a subscription in SCC anymore,',
+                 ' and removes all installed services') do |opt|
           @options[:deregister] = true
         end
 

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -35,7 +35,7 @@ module SUSE
       def deregister!
         @api.deregister(system_auth)
         System.remove_credentials
-        Zypper.remove_all_services
+        Zypper.remove_all_suse_services
       end
 
       # Announce system via SCC/Registration Proxy

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -35,6 +35,7 @@ module SUSE
       def deregister!
         @api.deregister(system_auth)
         System.remove_credentials
+        Zypper.remove_all_services
       end
 
       # Announce system via SCC/Registration Proxy

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -49,6 +49,16 @@ module SUSE
           call("--non-interactive removeservice '#{Shellwords.escape(service_name)}'")
         end
 
+        ##
+        # Returns an array of all installed service names
+        def services
+          output = call('services', false)
+          lines = output.split("\n").drop(2)
+          lines.map do |line|
+            line.split('|')[2].strip
+          end
+        end
+
         def refresh
           call('--non-interactive refresh')
         end

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -20,7 +20,7 @@ module SUSE
         # presented as a hash.
         def installed_products
           zypper_out = call('--xmlout --non-interactive products -i', false)
-          xml_doc = REXML::Document.new(zypper_out, :compress_whitespace => [])
+          xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
           ary_of_products_hashes = xml_doc.root.elements['product-list'].elements.map(&:to_hash)
           ary_of_products_hashes.map {|hash| Product.new(hash) }
         end

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -1,5 +1,6 @@
 require 'rexml/document'
 require 'shellwords'
+require 'fileutils'
 require 'suse/connect/rexml_refinement'
 require 'suse/toolkit/system_calls'
 
@@ -44,16 +45,28 @@ module SUSE
           call("--non-interactive addservice -t ris #{service}")
         end
 
-        # @param service_name [String] Alias-mnemonic with which zypper should add this service
+        # @param service_name [String] Alias-mnemonic with which zypper should remove this service
         def remove_service(service_name)
           call("--non-interactive removeservice '#{Shellwords.escape(service_name)}'")
+          remove_service_credentials(service_name)
         end
 
         ##
         # Remove all installed SUSE services
         def remove_all_suse_services
           services.each do |service|
-            remove_service(service[:name]) if service[:url].include?(Config.new.url)
+            if service[:url].include?(Config.new.url)
+              remove_service(service[:name])
+            end
+          end
+        end
+
+        # @param service_name [String] Alias-mnemonic with which service credentials file should be removed
+        def remove_service_credentials(service_name)
+          service_credentials_file = File.join(SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR, service_name)
+
+          if File.exist?(service_credentials_file)
+            File.delete service_credentials_file
           end
         end
 

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -75,9 +75,7 @@ module SUSE
         def services
           zypper_out = call('--xmlout --non-interactive services -d', false)
           xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
-          xml_doc.root.elements['service-list'].elements.map do |r|
-            r.to_hash.merge(url: r.get_elements('url').first.text)
-          end
+          xml_doc.elements.each('stream/service-list/service') {}.map(&:to_hash)
         end
 
         def refresh

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -50,6 +50,14 @@ module SUSE
         end
 
         ##
+        # Remove all installed services
+        def remove_all_services
+          services.map do |service_name|
+            remove_service(service_name)
+          end
+        end
+
+        ##
         # Returns an array of all installed service names
         def services
           output = call('services', false)

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -73,18 +73,10 @@ module SUSE
         ##
         # Returns an array of hashes of all installed services
         def services
-          output = call('services -u', false)
-          lines = output.split("\n").drop(2).map {|line| line.split('|').map(&:strip) }
-
-          lines.map do |line|
-            {
-              alias:    line[1],
-              name:     line[2],
-              enabled:  line[3],
-              refresh:  line[4],
-              type:     line[5],
-              url:      line[6]
-            }
+          zypper_out = call('--xmlout --non-interactive services -d', false)
+          xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
+          xml_doc.root.elements['service-list'].elements.map do |r|
+            r.to_hash.merge(url: r.get_elements('url').first.text)
           end
         end
 

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -50,21 +50,28 @@ module SUSE
         end
 
         ##
-        # Remove all installed services
-        def remove_all_services
-          services.map do |service_name|
-            remove_service(service_name)
+        # Remove all installed SUSE services
+        def remove_all_suse_services
+          services.each do |service|
+            remove_service(service[:name]) if service[:url].include?(Config.new.url)
           end
         end
 
         ##
-        # Returns an array of all installed service names
+        # Returns an array of hashes of all installed services
         def services
-          # FIXME: List only SCC seervices, detect them by service URL
-          output = call('services', false)
-          lines = output.split("\n").drop(2)
+          output = call('services -u', false)
+          lines = output.split("\n").drop(2).map {|line| line.split('|').map(&:strip) }
+
           lines.map do |line|
-            line.split('|')[2].strip
+            {
+              alias:    line[1],
+              name:     line[2],
+              enabled:  line[3],
+              refresh:  line[4],
+              type:     line[5],
+              url:      line[6]
+            }
           end
         end
 

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -60,6 +60,7 @@ module SUSE
         ##
         # Returns an array of all installed service names
         def services
+          # FIXME: List only SCC seervices, detect them by service URL
           output = call('services', false)
           lines = output.split("\n").drop(2)
           lines.map do |line|

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -138,7 +138,7 @@ describe SUSE::Connect::Cli do
     context 'de-register command' do
       it '--de-register calls deregister! method' do
         cli = subject.new(%w{--de-register})
-        expect_any_instance_of(Client).to_not receive(:deregister!)
+        expect_any_instance_of(Client).to receive(:deregister!)
         cli.execute!
       end
     end

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'suse/connect/cli'
 
 describe SUSE::Connect::Cli do
-
   subject { SUSE::Connect::Cli }
 
   let(:default_logger) { SUSE::Connect::GlobalLogger.instance.log }
@@ -22,9 +21,7 @@ describe SUSE::Connect::Cli do
   end
 
   describe '#execute!' do
-
     context 'server errors' do
-
       let(:cli) { subject.new(%w{-r 123}) }
 
       it 'should produce log output if ApiError encountered' do
@@ -78,11 +75,9 @@ describe SUSE::Connect::Cli do
         Client.any_instance.stub(:register!).and_raise(FileError, 'test')
         cli.execute!
       end
-
     end
 
     context 'zypper error' do
-
       let(:cli) { subject.new(%w{-r 456}) }
 
       it 'should produce log output if zypper errors' do
@@ -90,11 +85,9 @@ describe SUSE::Connect::Cli do
         Client.any_instance.stub(:register!).and_raise ZypperError.new(666, '<stream><error>zypper down</error></stream>')
         cli.execute!
       end
-
     end
 
     context 'parameter dependencies' do
-
       it 'requires no other parameters on --status' do
         cli = subject.new(%w{--status})
         expect_any_instance_of(Status).to receive(:print_product_statuses)
@@ -140,11 +133,17 @@ describe SUSE::Connect::Cli do
         expect_any_instance_of(SUSE::Connect::Config).to receive(:write!)
         cli.execute!
       end
+    end
 
+    context 'de-register command' do
+      it '--de-register calls deregister! method' do
+        cli = subject.new(%w{--de-register})
+        expect_any_instance_of(Client).to_not receive(:deregister!)
+        cli.execute!
+      end
     end
 
     context 'status subcommand' do
-
       it '--status calls json_product_status' do
         cli = subject.new(%w{--status})
         expect_any_instance_of(Client).to_not receive(:register!)
@@ -158,24 +157,19 @@ describe SUSE::Connect::Cli do
         expect_any_instance_of(Status).to receive(:text_product_status)
         cli.execute!
       end
-
     end
 
     describe 'config write' do
-
       it 'writes config if appropriate cli param been passed' do
         cli = subject.new(%w{--write-config --status})
         expect_any_instance_of(SUSE::Connect::Config).to receive(:write!)
         allow_any_instance_of(Status).to receive(:print_product_statuses)
         cli.execute!
       end
-
     end
-
   end
 
   describe '?extract_options' do
-
     it 'sets token options' do
       argv = %w{-r matoken}
       cli = subject.new(argv)
@@ -224,6 +218,12 @@ describe SUSE::Connect::Cli do
       cli.options[:debug].should be true
     end
 
+    it 'sets deregister option' do
+      argv = %w{--de-register}
+      cli = subject.new(argv)
+      cli.options[:deregister].should be true
+    end
+
     it 'sets root option' do
       argv = %w{--root /path/to/root}
       subject.new(argv)
@@ -241,17 +241,14 @@ describe SUSE::Connect::Cli do
       cli = subject.new(argv)
       cli.options[:write_config].should be true
     end
-
   end
 
   describe 'errors on invalid options format' do
-
     it 'error on invalid product options format' do
       string_logger.should_receive(:error).with(/Please provide the product identifier in this format/)
       argv = %w{--product sles}
       subject.new(argv)
     end
-
   end
 
   describe '?check_if_param' do
@@ -269,7 +266,5 @@ describe SUSE::Connect::Cli do
       cli = subject.new([])
       expect(cli.options[:language]).to eq 'de'
     end
-
   end
-
 end

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -10,9 +10,9 @@ describe SUSE::Connect::Cli do
   let(:config_file) { File.expand_path File.join(File.dirname(__FILE__), '../fixtures/SUSEConnect') }
 
   before do
-    Zypper.stub(:base_product => {})
+    Zypper.stub(base_product: {})
     subject.any_instance.stub(:exit)
-    subject.any_instance.stub(:puts => true)
+    subject.any_instance.stub(puts: true)
     SUSE::Connect::GlobalLogger.instance.log = string_logger
   end
 
@@ -179,7 +179,7 @@ describe SUSE::Connect::Cli do
     it 'sets product options' do
       argv = %w{--product sles/12/i386}
       cli = subject.new(argv)
-      cli.options[:product].should eq Remote::Product.new(:identifier => 'sles', :version => '12', :arch => 'i386')
+      cli.options[:product].should eq Remote::Product.new(identifier: 'sles', version: '12', arch: 'i386')
     end
 
     it 'sets token options' do

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -337,13 +337,14 @@ describe SUSE::Connect::Client do
     end
 
     before do
-      Zypper.should_receive(:remove_all_services).and_return(true)
-      System.should_receive(:remove_credentials).and_return(true)
       subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'calls underlying api and removes credentials file' do
-      subject.api.should_receive(:deregister).with('Basic: encodedstring').and_return stubbed_response
+      expect(Zypper).to receive(:remove_all_suse_services).and_return(true)
+      expect(System).to receive(:remove_credentials).and_return(true)
+      expect(subject.api).to receive(:deregister).with('Basic: encodedstring').and_return stubbed_response
+
       subject.deregister!.should be true
     end
   end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -337,6 +337,7 @@ describe SUSE::Connect::Client do
     end
 
     before do
+      Zypper.should_receive(:remove_all_services).and_return(true)
       System.should_receive(:remove_credentials).and_return(true)
       subject.stub(system_auth: 'Basic: encodedstring')
     end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -84,9 +84,9 @@ describe SUSE::Connect::Client do
 
       before do
         api_response = double('api_response')
-        api_response.stub(:body => { 'login' => 'lg', 'password' => 'pw' })
-        Api.any_instance.stub(:announce_system => api_response)
-        subject.stub(:token_auth => true)
+        api_response.stub(body: { 'login' => 'lg', 'password' => 'pw' })
+        Api.any_instance.stub(announce_system: api_response)
+        subject.stub(token_auth: true)
       end
 
       it 'calls underlying api' do
@@ -121,7 +121,7 @@ describe SUSE::Connect::Client do
         subject { SUSE::Connect::Client.new(config) }
 
         before do
-          subject.stub(:system_auth => 'auth')
+          subject.stub(system_auth: 'auth')
           Api.any_instance.stub(:update_system)
         end
 
@@ -153,10 +153,10 @@ describe SUSE::Connect::Client do
 
       before do
         api_response = double('api_response')
-        api_response.stub(:body => { 'login' => 'lg', 'password' => 'pw' })
+        api_response.stub(body: { 'login' => 'lg', 'password' => 'pw' })
         Zypper.stub(:write_base_credentials).with('lg', 'pw')
-        Api.any_instance.stub(:announce_system => api_response)
-        subject.stub(:token_auth => true)
+        Api.any_instance.stub(announce_system: api_response)
+        subject.stub(token_auth: true)
       end
 
       it 'not raising exception if regcode is absent' do
@@ -175,13 +175,13 @@ describe SUSE::Connect::Client do
 
   describe '#activate_product' do
 
-    let(:product_ident) { { :identifier => 'SLES', :version => '12', :arch => 'x86_64' } }
+    let(:product_ident) { { identifier: 'SLES', version: '12', arch: 'x86_64' } }
 
     before do
       api_response = double('api_response')
-      api_response.stub(:body => { 'name' => 'kinkat', 'url' => 'kinkaturl', 'product' => {} })
-      Api.any_instance.stub(:activate_product => api_response)
-      subject.stub(:system_auth => 'secretsecret')
+      api_response.stub(body: { 'name' => 'kinkat', 'url' => 'kinkaturl', 'product' => {} })
+      Api.any_instance.stub(activate_product: api_response)
+      subject.stub(system_auth: 'secretsecret')
     end
 
     it 'gets login and password from system' do
@@ -210,13 +210,13 @@ describe SUSE::Connect::Client do
 
   describe '#upgrade_product' do
 
-    let(:product_ident) { { :identifier => 'SLES', :version => '12', :arch => 'x86_64' } }
+    let(:product_ident) { { identifier: 'SLES', version: '12', arch: 'x86_64' } }
 
     before do
       api_response = double('api_response')
-      api_response.stub(:body => { 'name' => 'tongobongo', 'url' => 'tongobongourl', 'product' => {} })
-      Api.any_instance.stub(:upgrade_product => api_response)
-      subject.stub(:system_auth => 'secretsecret')
+      api_response.stub(body: { 'name' => 'tongobongo', 'url' => 'tongobongourl', 'product' => {} })
+      Api.any_instance.stub(upgrade_product: api_response)
+      subject.stub(system_auth: 'secretsecret')
     end
 
     it 'gets login and password from system' do
@@ -240,8 +240,8 @@ describe SUSE::Connect::Client do
   describe '#register!' do
 
     before do
-      Zypper.stub(:base_product => Zypper::Product.new(:name => 'SLE_BASE'))
-      System.stub(:add_service => true)
+      Zypper.stub(base_product: Zypper::Product.new(name: 'SLE_BASE'))
+      System.stub(add_service: true)
       Zypper.stub(:write_base_credentials)
       Credentials.any_instance.stub(:write)
       subject.stub(:activate_product)
@@ -249,33 +249,33 @@ describe SUSE::Connect::Client do
     end
 
     it 'should call announce if system not registered' do
-      System.stub(:credentials? => false)
+      System.stub(credentials?: false)
       subject.should_receive(:announce_system)
       subject.register!
     end
 
     it 'should not call announce but update on api if system registered' do
-      System.stub(:credentials? => true)
+      System.stub(credentials?: true)
       subject.should_not_receive(:announce_system)
       subject.should_receive(:update_system)
       subject.register!
     end
 
     it 'should call activate_product on api' do
-      System.stub(:credentials? => true)
+      System.stub(credentials?: true)
       subject.should_receive(:activate_product)
       subject.register!
     end
 
     it 'writes credentials file' do
-      System.stub(:credentials? => false)
-      subject.stub(:announce_system => %w{ lg pw })
+      System.stub(credentials?: false)
+      subject.stub(announce_system: %w{ lg pw })
       Credentials.should_receive(:new).with('lg', 'pw', Credentials::GLOBAL_CREDENTIALS_FILE).and_call_original
       subject.register!
     end
 
     it 'adds service after product activation' do
-      System.stub(:credentials? => true)
+      System.stub(credentials?: true)
       System.should_receive(:add_service)
       subject.register!
     end
@@ -286,7 +286,7 @@ describe SUSE::Connect::Client do
       client = Client.new(merged_config)
       client.stub(:announce_or_update)
       client.stub(:activate_product)
-      Zypper.stub(:base_product => product)
+      Zypper.stub(base_product: product)
       SUSE::Connect::GlobalLogger.instance.log = string_logger
 
       string_logger.should_receive(:info).with('Registered SLES 12 s390')
@@ -303,16 +303,16 @@ describe SUSE::Connect::Client do
 
     let(:stubbed_response) do
       OpenStruct.new(
-        :code => 200,
-        :body => { 'name' => 'short_name', 'identifier' => 'text_identifier' },
-        :success => true
+        code: 200,
+        body: { 'name' => 'short_name', 'identifier' => 'text_identifier' },
+        success: true
       )
     end
 
-    let(:product) { Remote::Product.new(:identifier => 'text_identifier')  }
+    let(:product) { Remote::Product.new(identifier: 'text_identifier')  }
 
     before do
-      subject.stub(:system_auth => 'Basic: encodedstring')
+      subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'collects data from api response' do
@@ -330,15 +330,15 @@ describe SUSE::Connect::Client do
   describe '#deregister!' do
     let(:stubbed_response) do
       OpenStruct.new(
-        :code => 204,
-        :body => nil,
-        :success => true
+        code: 204,
+        body: nil,
+        success: true
       )
     end
 
     before do
       System.should_receive(:remove_credentials).and_return(true)
-      subject.stub(:system_auth => 'Basic: encodedstring')
+      subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'calls underlying api and removes credentials file' do
@@ -350,14 +350,14 @@ describe SUSE::Connect::Client do
   describe '#systems_services' do
     let(:stubbed_response) do
       OpenStruct.new(
-          :code => 204,
-          :body => nil,
-          :success => true
+          code: 204,
+          body: nil,
+          success: true
       )
     end
 
     before do
-      subject.stub(:system_auth => 'Basic: encodedstring')
+      subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'calls underlying api and removes credentials file' do
@@ -369,14 +369,14 @@ describe SUSE::Connect::Client do
   describe '#systems_subscriptions' do
     let(:stubbed_response) do
       OpenStruct.new(
-          :code => 204,
-          :body => nil,
-          :success => true
+          code: 204,
+          body: nil,
+          success: true
       )
     end
 
     before do
-      subject.stub(:system_auth => 'Basic: encodedstring')
+      subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'calls underlying api and removes credentials file' do
@@ -389,14 +389,14 @@ describe SUSE::Connect::Client do
 
     let(:stubbed_response) do
       OpenStruct.new(
-          :code => 200,
-          :body => nil,
-          :success => true
+          code: 200,
+          body: nil,
+          success: true
       )
     end
 
     before do
-      subject.stub(:system_auth => 'Basic: encodedstring')
+      subject.stub(system_auth: 'Basic: encodedstring')
     end
 
     it 'calls underlying api with system_activations call' do

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -106,6 +106,7 @@ describe SUSE::Connect::Zypper do
     it 'calls zypper with proper arguments' do
       args = "zypper --non-interactive removeservice 'branding'"
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
+      expect(Zypper).to receive(:remove_service_credentials).with('branding')
 
       subject.remove_service('branding')
     end
@@ -136,7 +137,6 @@ describe SUSE::Connect::Zypper do
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
 
       subject.remove_all_suse_services
-
     end
 
     it 'removes SMT installed services' do
@@ -146,7 +146,6 @@ describe SUSE::Connect::Zypper do
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
 
       subject.remove_all_suse_services
-
     end
 
     it 'removes legacy services' do
@@ -156,7 +155,20 @@ describe SUSE::Connect::Zypper do
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
 
       subject.remove_all_suse_services
+    end
+  end
 
+  describe '.remove_service_credentials' do
+    let(:service_name) { 'SLES_12_Service' }
+    let(:service_credentials_dir) { SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR }
+    let(:service_credentials_file) { File.join(service_credentials_dir, service_name) }
+
+    it 'removes zypper service credentials' do
+      expect(File).to receive(:join).with(service_credentials_dir, service_name).and_return(service_credentials_file)
+      expect(File).to receive(:exist?).with(service_credentials_file).and_return(true)
+      expect(File).to receive(:delete).with(service_credentials_file).and_return(true)
+
+      subject.remove_service_credentials(service_name)
     end
   end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -121,12 +121,33 @@ describe SUSE::Connect::Zypper do
 
   end
 
+  describe '.remove_all_services' do
+    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services') }
+    let(:args) { 'zypper services' }
+
+    before do
+      expect(Open3).to receive(:capture3).with(shared_env_hash, args).at_least(1).and_return([zypper_services_output, '', status])
+    end
+
+    it 'removes all installed services.' do
+      subject.services.each do |service_name|
+        args = "zypper --non-interactive removeservice '#{service_name}'"
+        expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
+      end
+
+      subject.remove_all_services
+    end
+  end
+
   describe '.services' do
     let(:zypper_services_output) { File.read('spec/fixtures/zypper_services') }
-    it 'lists all defined services.' do
-      args = 'zypper services'
-      expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return([zypper_services_output, '', status])
+    let(:args) { 'zypper services' }
 
+    before do
+      expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return([zypper_services_output, '', status])
+    end
+
+    it 'lists all defined services.' do
       expect(subject.services).to match_array(%w{sles12ga sles12gaup})
     end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -121,6 +121,17 @@ describe SUSE::Connect::Zypper do
 
   end
 
+  describe '.services' do
+    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services') }
+    it 'lists all defined services.' do
+      args = 'zypper services'
+      expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return([zypper_services_output, '', status])
+
+      expect(subject.services).to match_array(%w{sles12ga sles12gaup})
+    end
+
+  end
+
   describe '.refresh' do
 
     it 'calls zypper with proper arguments' do

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -123,8 +123,8 @@ describe SUSE::Connect::Zypper do
   end
 
   describe '.remove_all_suse_services' do
-    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services') }
-    let(:service_args) { 'zypper services -u' }
+    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services.xml') }
+    let(:service_args) { 'zypper --xmlout --non-interactive services -d' }
 
     before do
       expect(Open3).to receive(:capture3).with(shared_env_hash, service_args).at_least(1).and_return([zypper_services_output, '', status])
@@ -173,8 +173,8 @@ describe SUSE::Connect::Zypper do
   end
 
   describe '.services' do
-    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services') }
-    let(:args) { 'zypper services -u' }
+    let(:zypper_services_output) { File.read('spec/fixtures/zypper_services.xml') }
+    let(:args) { 'zypper --xmlout --non-interactive services -d' }
 
     before do
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).at_least(1).and_return([zypper_services_output, '', status])
@@ -182,7 +182,7 @@ describe SUSE::Connect::Zypper do
 
     it 'lists all defined services.' do
       expect(subject.services.size).to eq 3
-      expect(subject.services.first.keys).to match_array([:alias, :name, :enabled, :refresh, :type, :url])
+      expect(subject.services.first.keys).to match_array([:alias, :autorefresh, :enabled, :gpgcheck, :name, :priority, :type, :url])
       expect(subject.services.map {|service| service[:name] }).to match_array(%w{scc_sles12 smt_sles12 legacy_sles12})
     end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SUSE::Connect::Zypper do
 
   before(:each) do
-    Object.stub(:system => true)
+    Object.stub(system: true)
   end
 
   after(:each) do
@@ -11,7 +11,7 @@ describe SUSE::Connect::Zypper do
   end
 
   subject { SUSE::Connect::Zypper }
-  let(:status) { double('Process Status', :exitstatus => 0) }
+  let(:status) { double('Process Status', exitstatus: 0) }
   include_context 'shared lets'
 
   describe '.installed_products' do
@@ -191,13 +191,13 @@ describe SUSE::Connect::Zypper do
 
     let :parsed_products do
       [
-        SUSE::Connect::Zypper::Product.new(:isbase => '1', :name => 'SLES', :productline => 'SLE_productline1', :registerrelease => ''),
-        SUSE::Connect::Zypper::Product.new(:isbase => '2', :name => 'Cloud', :productline => 'SLE_productline2', :registerrelease => '')
+        SUSE::Connect::Zypper::Product.new(isbase: '1', name: 'SLES', productline: 'SLE_productline1', registerrelease: ''),
+        SUSE::Connect::Zypper::Product.new(isbase: '2', name: 'Cloud', productline: 'SLE_productline2', registerrelease: '')
       ]
     end
 
     before do
-      subject.stub(:installed_products => parsed_products)
+      subject.stub(installed_products: parsed_products)
       Credentials.any_instance.stub(:write)
     end
 
@@ -206,7 +206,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'raises CannotDetectBaseProduct if cant get base system from list of installed products' do
-      product = double('Product', :isbase => false)
+      product = double('Product', isbase: false)
       allow(Zypper).to receive(:installed_products).and_return([product])
       expect { Zypper.base_product }.to raise_error(CannotDetectBaseProduct)
     end

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -182,7 +182,7 @@ describe SUSE::Connect::Zypper do
 
     it 'lists all defined services.' do
       expect(subject.services.size).to eq 3
-      expect(subject.services.first.keys).to match_array([:alias, :autorefresh, :enabled, :gpgcheck, :name, :priority, :type, :url])
+      expect(subject.services.first.keys).to match_array([:alias, :autorefresh, :enabled, :name, :type, :url])
       expect(subject.services.map {|service| service[:name] }).to match_array(%w{scc_sles12 smt_sles12 legacy_sles12})
     end
 

--- a/spec/fixtures/zypper_services
+++ b/spec/fixtures/zypper_services
@@ -1,4 +1,5 @@
-# | Alias                  | Name                           | Enabled | Refresh
---+------------------------+--------------------------------+---------+--------
-1 | sles12ga               | sles12ga                       | Yes     | No
-2 | sles12gaup             | sles12gaup                     | Yes     | Yes
+# | Alias                  | Name                           | Enabled | Refresh | Type   | URI
+--+------------------------+--------------------------------+---------+---------+--------+---------------------------------------------------------------------------
+1 | scc_sles12             | scc_sles12                     | Yes     | No      | rpm-md | https://scc.suse.com/repos/SLES12-GA-Pool/
+2 | smt_sles12             | smt_sles12                     | Yes     | Yes     | rpm-md | http://smt.suse.de/repos/SLES12-GA-Pool/
+3 | legacy_sles12          | legacy_sles12                  | Yes     | Yes     | rpm-md | http://legacy.suse.de/repos/SLES12-GA-Pool/

--- a/spec/fixtures/zypper_services
+++ b/spec/fixtures/zypper_services
@@ -1,5 +1,5 @@
 # | Alias                  | Name                           | Enabled | Refresh | Type   | URI
 --+------------------------+--------------------------------+---------+---------+--------+---------------------------------------------------------------------------
 1 | scc_sles12             | scc_sles12                     | Yes     | No      | rpm-md | https://scc.suse.com/repos/SLES12-GA-Pool/
-2 | smt_sles12             | smt_sles12                     | Yes     | Yes     | rpm-md | http://smt.suse.de/repos/SLES12-GA-Pool/
-3 | legacy_sles12          | legacy_sles12                  | Yes     | Yes     | rpm-md | http://legacy.suse.de/repos/SLES12-GA-Pool/
+2 | smt_sles12             | smt_sles12                     | Yes     | Yes     | rpm-md | https://smt.suse.de/repos/SLES12-GA-Pool/
+3 | legacy_sles12          | legacy_sles12                  | Yes     | Yes     | rpm-md | https://legacy.suse.de/repos/SLES12-GA-Pool/

--- a/spec/fixtures/zypper_services
+++ b/spec/fixtures/zypper_services
@@ -1,0 +1,4 @@
+# | Alias                  | Name                           | Enabled | Refresh
+--+------------------------+--------------------------------+---------+--------
+1 | sles12ga               | sles12ga                       | Yes     | No
+2 | sles12gaup             | sles12gaup                     | Yes     | Yes

--- a/spec/fixtures/zypper_services
+++ b/spec/fixtures/zypper_services
@@ -1,5 +1,0 @@
-# | Alias                  | Name                           | Enabled | Refresh | Type   | URI
---+------------------------+--------------------------------+---------+---------+--------+---------------------------------------------------------------------------
-1 | scc_sles12             | scc_sles12                     | Yes     | No      | rpm-md | https://scc.suse.com/repos/SLES12-GA-Pool/
-2 | smt_sles12             | smt_sles12                     | Yes     | Yes     | rpm-md | https://smt.suse.de/repos/SLES12-GA-Pool/
-3 | legacy_sles12          | legacy_sles12                  | Yes     | Yes     | rpm-md | https://legacy.suse.de/repos/SLES12-GA-Pool/

--- a/spec/fixtures/zypper_services.xml
+++ b/spec/fixtures/zypper_services.xml
@@ -1,14 +1,22 @@
 <?xml version='1.0'?>
 <stream>
   <service-list>
-    <repo alias="scc_sles12" name="scc_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
-    <url>https://scc.suse.com/repos/SLES12-GA-Pool/</url>
-  </repo>
-  <repo alias="smt_sles12" name="smt_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
-    <url>https://smt.suse.de/repos/SLES12-GA-Pool/</url>
-  </repo>
-  <repo alias="legacy_sles12" name="legacy_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
-    <url>https://legacy.suse.de/repos/SLES12-GA-Pool/</url>
-  </repo>
+    <service alias='scc_sles12' autorefresh='0' enabled='1' name='scc_sles12' type='ris' url='https://scc.suse.com/access/services/1?credentials=scc_sles12'>
+      <repo alias='scc_sles12_repo' autorefresh='0' enabled='0' gpgcheck='1' name='scc_sles12_repo' priority='99' type='rpm-md'>
+        <url>https://scc.suse.com/repos/SLES12-GA-Pool/</url>
+      </repo>
+    </service>
+
+    <service alias='smt_sles12' autorefresh='0' enabled='1' name='smt_sles12' type='ris' url='https://smt.suse.de/access/services/1?credentials=smt_sles12'>
+      <repo alias='smt_sles12_repo' autorefresh='0' enabled='0' gpgcheck='1' name='scc_sles12_repo' priority='99' type='rpm-md'>
+        <url>https://smt.suse.de/repos/SLES12-GA-Pool/</url>
+      </repo>
+    </service>
+
+    <service alias='legacy_sles12' autorefresh='0' enabled='1' name='legacy_sles12' type='ris' url='https://legacy.suse.de/access/services/1?credentials=legacy_sles12'>
+      <repo alias='legacy_sles12_repo' autorefresh='0' enabled='0' gpgcheck='1' name='legacy_sles12_repo' priority='99' type='rpm-md'>
+        <url>https://legacy.suse.de/repos/SLES12-GA-Pool/</url>
+      </repo>
+    </service>
   </service-list>
 </stream>

--- a/spec/fixtures/zypper_services.xml
+++ b/spec/fixtures/zypper_services.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0'?>
+<stream>
+  <service-list>
+    <repo alias="scc_sles12" name="scc_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
+    <url>https://scc.suse.com/repos/SLES12-GA-Pool/</url>
+  </repo>
+  <repo alias="smt_sles12" name="smt_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
+    <url>https://smt.suse.de/repos/SLES12-GA-Pool/</url>
+  </repo>
+  <repo alias="legacy_sles12" name="legacy_sles12" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
+    <url>https://legacy.suse.de/repos/SLES12-GA-Pool/</url>
+  </repo>
+  </service-list>
+</stream>


### PR DESCRIPTION
Please review the following changes:
  * 156213b move de-register test back before status error tests
  * 7c81461 move de-register test to the end of a feature file
  * a365889 remove zypper credentials file after removing the corresponding service
  * 011b851 new rspec expect syntax
  * 72fd03f ensure services were remove after de-register
  * f0b1f3d adapt wording in a help text
  * e554162 fix integration test
  * 36ee73b return array of hashes for all installed services and delete SUSE services only
  * 052befb fixture should include scc, smt and legacy services
  * 21767ca add FIXME
  * 23d32a4 call System.deregister! if cli deregister option is set
  * fddb833 ruby 1.9 hash style
  * 7787159 Client.deregister! should remove all installed services
  * 7e390ca add .remove_all_services for removing installed services
  * c19b58b parse `zypper services` output and return array of service names
  * 9137322 add -d, --de-register option to cmd
  * 345f4c8 ruby 1.9 hash style