### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150601__3_smt_suseconnect_should_be_able_to_provide_a_namespace_parameter_2620'

### DIFF
--- a/kitchen/Vagrantfile
+++ b/kitchen/Vagrantfile
@@ -7,6 +7,7 @@
 
 
 @vm_name = ENV['VM_NAME'] || "jenkins_scc_connect_build_#{ENV['BUILD_NUMBER']}"
+@branch = `git rev-parse --abbrev-ref HEAD`.strip.empty? ? 'master' : `git rev-parse --abbrev-ref HEAD`.strip
 
 Vagrant.configure('2') do |config|
   config.librarian_chef.cheffile_dir = '.'
@@ -35,6 +36,9 @@ Vagrant.configure('2') do |config|
       chef.cookbooks_path = 'cookbooks'
       chef.roles_path = 'roles'
       chef.add_role 'connect_test_node'
+      chef.json = {
+        branch: @branch
+      }
     end
   end
 end

--- a/kitchen/vendor/cookbooks/connect/recipes/suse_connect.rb
+++ b/kitchen/vendor/cookbooks/connect/recipes/suse_connect.rb
@@ -1,6 +1,6 @@
 git '/tmp/connect' do
   repository 'https://github.com/SUSE/connect.git'
-  reference 'master'
+  reference  node[:branch] || 'master'
   action 'sync'
   user 'vagrant'
   group 'users'
@@ -67,6 +67,6 @@ end
 
 zypper_options = '--non-interactive  --no-gpg-checks'
 execute 'install SUSEConnect RPM' do
-  command "zypper #{zypper_options} in /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*"
+  command "zypper #{zypper_options} in --force /var/tmp/build-root/SLE_12-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*"
   cwd "#{node[:connect][:project]}/package"
 end

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -20,10 +20,10 @@ module SUSE
         @client     = client
         @connection = Connection.new(
           client.config.url,
-          :language        => client.config.language,
-          :insecure        => client.config.insecure,
-          :verify_callback => client.config.verify_callback,
-          :debug           => client.config.debug
+          language:        client.config.language,
+          insecure:        client.config.insecure,
+          verify_callback: client.config.verify_callback,
+          debug:           client.config.debug
         )
       end
 
@@ -36,15 +36,15 @@ module SUSE
       #
       def announce_system(auth, distro_target = nil, instance_data = nil, namespace = nil)
         payload = {
-          :hostname      => System.hostname,
-          :hwinfo        => System.hwinfo,
-          :distro_target => distro_target || Zypper.distro_target
+          hostname:      System.hostname,
+          hwinfo:        System.hwinfo,
+          distro_target: distro_target || Zypper.distro_target
         }
 
         payload[:instance_data] = instance_data if instance_data
         payload[:namespace] = namespace if namespace
 
-        @connection.post('/connect/subscriptions/systems', :auth => auth, :params => payload)
+        @connection.post('/connect/subscriptions/systems', auth: auth, params: payload)
       end
 
       # Re-send the system's hardware info to SCC.
@@ -56,14 +56,14 @@ module SUSE
       #
       def update_system(auth, distro_target = nil, instance_data = nil, namespace = nil)
         payload = {
-          :hostname      => System.hostname,
-          :hwinfo        => System.hwinfo,
-          :distro_target => distro_target || Zypper.distro_target
+          hostname:      System.hostname,
+          hwinfo:        System.hwinfo,
+          distro_target: distro_target || Zypper.distro_target
         }
         payload[:instance_data] = instance_data if instance_data
         payload[:namespace] = namespace if namespace
 
-        @connection.put('/connect/systems', :auth => auth, :params => payload)
+        @connection.put('/connect/systems', auth: auth, params: payload)
       end
 
       # Activate a product, consuming an entitlement, and receive the service for this
@@ -78,14 +78,14 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       def activate_product(auth, product, email = nil)
         payload = {
-          :identifier   => product.identifier,
-          :version      => product.version,
-          :arch         => product.arch,
-          :release_type => product.release_type,
-          :token        => @client.config.token,
-          :email        => email
+          identifier:   product.identifier,
+          version:      product.version,
+          arch:         product.arch,
+          release_type: product.release_type,
+          token:        @client.config.token,
+          email:        email
         }
-        @connection.post('/connect/systems/products', :auth => auth, :params => payload)
+        @connection.post('/connect/systems/products', auth: auth, params: payload)
       end
 
       # Upgrade a product and receive the updated service for the system.
@@ -94,7 +94,7 @@ module SUSE
       #   In this case we expect Base64 encoded string with login and password
       # @param product [SUSE::Connect::Remote::Product] product
       def upgrade_product(auth, product)
-        @connection.put('/connect/systems/products', :auth => auth, :params => product.to_params)
+        @connection.put('/connect/systems/products', auth: auth, params: product.to_params)
       end
 
       # Show details of an (activated) product including repositories and available extensions
@@ -102,7 +102,7 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       #
       def show_product(auth, product)
-        @connection.get('/connect/systems/products', :auth => auth, :params => product.to_params)
+        @connection.get('/connect/systems/products', auth: auth, params: product.to_params)
       end
 
       # Deregister/unregister a system
@@ -113,7 +113,7 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       #
       def deregister(auth)
-        @connection.delete('/connect/systems', :auth => auth)
+        @connection.delete('/connect/systems', auth: auth)
       end
 
       # Gets a list of services known by the system with system credentials
@@ -124,7 +124,7 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       #
       def system_services(auth)
-        @connection.get('/connect/systems/services', :auth => auth)
+        @connection.get('/connect/systems/services', auth: auth)
       end
 
       # Gets a list of subscriptions known by system authenticated with system credentials
@@ -135,7 +135,7 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       #
       def system_subscriptions(auth)
-        @connection.get('/connect/systems/subscriptions', :auth => auth)
+        @connection.get('/connect/systems/subscriptions', auth: auth)
       end
 
       # Gets a list of activations known by system authenticated with system credentials
@@ -146,7 +146,7 @@ module SUSE
       # @return [OpenStruct] responding to body(response from SCC) and code(natural HTTP response code).
       #
       def system_activations(auth)
-        @connection.get('/connect/systems/activations', :auth => auth)
+        @connection.get('/connect/systems/activations', auth: auth)
       end
 
       # Lists all available upgrade paths for a given list of products

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -34,13 +34,16 @@ module SUSE
       # In this case we expect Token authentication where token is a registration code e.g. 'Token token=<REGCODE>'
       # @return [OpenStruct] responding to #body(response from SCC), #code(natural HTTP response code) and #success.
       #
-      def announce_system(auth, distro_target = nil, instance_data = nil)
+      def announce_system(auth, distro_target = nil, instance_data = nil, namespace = nil)
         payload = {
           :hostname      => System.hostname,
           :hwinfo        => System.hwinfo,
           :distro_target => distro_target || Zypper.distro_target
         }
+
         payload[:instance_data] = instance_data if instance_data
+        payload[:namespace] = namespace if namespace
+
         @connection.post('/connect/subscriptions/systems', :auth => auth, :params => payload)
       end
 
@@ -51,13 +54,15 @@ module SUSE
       #   In this case we expect Base64 encoded string with login and password
       # @return [OpenStruct] responding to #body(response from SCC), #code(natural HTTP response code) and #success.
       #
-      def update_system(auth, distro_target = nil, instance_data = nil)
+      def update_system(auth, distro_target = nil, instance_data = nil, namespace = nil)
         payload = {
           :hostname      => System.hostname,
           :hwinfo        => System.hwinfo,
           :distro_target => distro_target || Zypper.distro_target
         }
         payload[:instance_data] = instance_data if instance_data
+        payload[:namespace] = namespace if namespace
+
         @connection.put('/connect/systems', :auth => auth, :params => payload)
       end
 

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -132,6 +132,11 @@ module SUSE
           @options[:write_config] = true
         end
 
+        @opts.on('--namespace [NAMESPACE]', 'namespace option for use with SMT staging environments') do |opt|
+          check_if_param(opt, 'Please provide a namespace')
+          @options[:namespace] = opt
+        end
+
         @opts.on('-s', '--status', 'get current system registration status in json format') do |opt|
           @options[:status] = true
         end

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -43,7 +43,10 @@ module SUSE
       # @returns: [Array] login, password tuple. Those credentials are given by SCC/Registration Proxy
       def announce_system(distro_target = nil, instance_data_file = nil)
         instance_data = System.read_file(instance_data_file) if instance_data_file
-        response = @api.announce_system(token_auth(@config.token), distro_target, instance_data)
+        params = [token_auth(@config.token), distro_target, instance_data]
+        params.push(@config.namespace) if @config.namespace
+
+        response = @api.announce_system(*params)
         [response.body['login'], response.body['password']]
       end
 
@@ -51,7 +54,10 @@ module SUSE
       #
       def update_system(distro_target = nil, instance_data_file = nil)
         instance_data = System.read_file(instance_data_file) if instance_data_file
-        @api.update_system(system_auth, distro_target, instance_data)
+        params = [system_auth, distro_target, instance_data]
+        params.push(@config.namespace) if @config.namespace
+
+        @api.update_system(*params)
       end
 
       # Activate a product

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -80,6 +80,17 @@ describe SUSE::Connect::Api do
       subject.new(client).announce_system('token', nil, '<test>')
     end
 
+    it 'sets namespace data in payload' do
+      namespace = 'SMT namespace'
+
+      Connection.any_instance.should_receive(:post)
+        .with('/connect/subscriptions/systems',
+              auth: 'token',
+              params: { hostname: 'connect', hwinfo: 'hwinfo', distro_target: 'HHH', namespace: namespace })
+        .and_call_original
+      subject.new(client).announce_system('token', nil, nil, namespace)
+    end
+
     context :hostname_detected do
 
       it 'sends a call with hostname' do
@@ -350,7 +361,7 @@ describe SUSE::Connect::Api do
     end
   end
 
-  describe 'update' do
+  describe 'update_system' do
 
     before do
       stub_update_call
@@ -377,6 +388,20 @@ describe SUSE::Connect::Api do
     it 'returns empty body' do
       body = subject.new(client).update_system('Basic: encodedgibberish').body
       body.should be_nil
+    end
+
+    it 'sets namespace data in payload' do
+      namespace = 'SMT namespace'
+
+      params = { hostname: 'connect', hwinfo: 'hwinfo', distro_target: 'openSUSE-4.1-x86_64', namespace: namespace }
+      payload = [
+        '/connect/systems',
+        auth: 'Basic: encodedgibberish',
+        params: params
+      ]
+
+      Connection.any_instance.should_receive(:put).with(*payload).and_call_original
+      subject.new(client).update_system('Basic: encodedgibberish', nil, nil, namespace)
     end
   end
 

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -44,10 +44,10 @@ describe SUSE::Connect::Api do
 
     before do
       stub_announce_call
-      Socket.stub(:gethostname => 'connect')
-      System.stub(:hwinfo => 'hwinfo')
-      Zypper.stub(:write_base_credentials => true)
-      Zypper.stub(:distro_target => 'HHH')
+      Socket.stub(gethostname: 'connect')
+      System.stub(hwinfo: 'hwinfo')
+      Zypper.stub(write_base_credentials: true)
+      Zypper.stub(distro_target: 'HHH')
     end
 
     mock_dry_file
@@ -74,8 +74,8 @@ describe SUSE::Connect::Api do
     it 'sets instance data in payload' do
       Connection.any_instance.should_receive(:post)
         .with('/connect/subscriptions/systems',
-              :auth => 'token',
-              :params => { :hostname => 'connect', :hwinfo => 'hwinfo', :distro_target => 'HHH', :instance_data => '<test>' })
+              auth: 'token',
+              params: { hostname: 'connect', hwinfo: 'hwinfo', distro_target: 'HHH', instance_data: '<test>' })
         .and_call_original
       subject.new(client).announce_system('token', nil, '<test>')
     end
@@ -83,8 +83,8 @@ describe SUSE::Connect::Api do
     context :hostname_detected do
 
       it 'sends a call with hostname' do
-        payload = ['/connect/subscriptions/systems', :auth => 'token', :params => {
-          :hostname => 'connect', :hwinfo => 'hwinfo', :distro_target => 'HHH' }
+        payload = ['/connect/subscriptions/systems', auth: 'token', params: {
+          hostname: 'connect', hwinfo: 'hwinfo', distro_target: 'HHH' }
         ]
         Connection.any_instance.should_receive(:post).with(*payload).and_call_original
         subject.new(client).announce_system('token')
@@ -95,10 +95,10 @@ describe SUSE::Connect::Api do
     context :no_hostname do
 
       it 'sends a call with ip when hostname is nil' do
-        Socket.stub(:gethostname => nil)
-        Socket.stub(:ip_address_list => [Addrinfo.ip('192.168.42.42')])
-        payload = ['/connect/subscriptions/systems', :auth => 'token', :params => {
-          :hostname => '192.168.42.42', :hwinfo => 'hwinfo', :distro_target => 'HHH' }
+        Socket.stub(gethostname: nil)
+        Socket.stub(ip_address_list: [Addrinfo.ip('192.168.42.42')])
+        payload = ['/connect/subscriptions/systems', auth: 'token', params: {
+          hostname: '192.168.42.42', hwinfo: 'hwinfo', distro_target: 'HHH' }
         ]
         Connection.any_instance.should_receive(:post).with(*payload).and_call_original
         subject.new(client).announce_system('token')
@@ -119,12 +119,12 @@ describe SUSE::Connect::Api do
     describe :services do
 
       it 'returns returns array of services as known by the system' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/services', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/services', auth: 'basic_auth_string').and_call_original
         subject.new(client).system_services('basic_auth_string')
       end
 
       it 'holds expected structure' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/services', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/services', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_services('basic_auth_string').body
         result.should be_kind_of Array
         result.first.keys.should eq %w{id name product}
@@ -139,12 +139,12 @@ describe SUSE::Connect::Api do
       end
 
       it 'returns returns array of subscriptions known by the system' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/subscriptions', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/subscriptions', auth: 'basic_auth_string').and_call_original
         subject.new(client).system_subscriptions('basic_auth_string')
       end
 
       it 'holds expected structure' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/subscriptions', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/subscriptions', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_subscriptions('basic_auth_string').body
         result.should be_kind_of Array
         attr_ary = %w{id regcode name type status starts_at expires_at}
@@ -161,12 +161,12 @@ describe SUSE::Connect::Api do
       end
 
       it 'returns returns array of subscriptions known by the system' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/activations', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/activations', auth: 'basic_auth_string').and_call_original
         subject.new(client).system_activations('basic_auth_string')
       end
 
       it 'holds expected structure' do
-        Connection.any_instance.should_receive(:get).with('/connect/systems/activations', :auth => 'basic_auth_string').and_call_original
+        Connection.any_instance.should_receive(:get).with('/connect/systems/activations', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_activations('basic_auth_string').body
         result.should be_kind_of Array
         attr_ary = %w{id regcode type status starts_at expires_at system_id service}
@@ -182,23 +182,23 @@ describe SUSE::Connect::Api do
     let(:api_endpoint) { '/connect/systems/products' }
     let(:system_auth) { 'basic_auth_mock' }
 
-    let(:product) { Remote::Product.new(:identifier => 'SLES', :version => '11-SP2', :arch => 'x86_64', :token => 'token-shmocken') }
+    let(:product) { Remote::Product.new(identifier: 'SLES', version: '11-SP2', arch: 'x86_64', token: 'token-shmocken') }
 
     let(:payload) do
       {
-        :identifier   => 'SLES',
-        :version      => '11-SP2',
-        :arch         => 'x86_64',
-        :release_type => nil,
-        :token        => 'token-shmocken',
-        :email        => nil
+        identifier:   'SLES',
+        version:      '11-SP2',
+        arch:         'x86_64',
+        release_type: nil,
+        token:        'token-shmocken',
+        email:        nil
       }
     end
 
     it 'calls ConnectAPI with basic auth and params and receives a JSON in return (use proper webmock)' do
       stub_activate_call
       Connection.any_instance.should_receive(:post)
-        .with(api_endpoint, :auth => system_auth, :params => payload)
+        .with(api_endpoint, auth: system_auth, params: payload)
         .and_call_original
       response = subject.new(client).activate_product(system_auth, product)
       response.body['name'].should eq 'SUSE_Linux_Enterprise_Server_12_x86_64'
@@ -208,7 +208,7 @@ describe SUSE::Connect::Api do
       email = 'email@domain.com'
       payload[:email] = email
       Connection.any_instance.should_receive(:post)
-        .with(api_endpoint, :auth => system_auth, :params => payload)
+        .with(api_endpoint, auth: system_auth, params: payload)
       subject.new(client).activate_product(system_auth, product, email)
     end
 
@@ -218,12 +218,12 @@ describe SUSE::Connect::Api do
 
     let(:api_endpoint) { '/connect/systems/products' }
     let(:system_auth) { 'basic_auth_mock' }
-    let(:product) { Remote::Product.new(:identifier => 'SLES', :version => '12', :arch => 'x86_64') }
+    let(:product) { Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64') }
 
     it 'calls ConnectAPI with basic auth and params and receives a JSON in return' do
       stub_upgrade_call
       Connection.any_instance.should_receive(:put)
-      .with(api_endpoint, :auth => system_auth, :params => product.to_params)
+      .with(api_endpoint, auth: system_auth, params: product.to_params)
       .and_call_original
       response = subject.new(client).upgrade_product(system_auth, product)
       response.body['sources'].keys.first.should include('SUSE')
@@ -237,13 +237,13 @@ describe SUSE::Connect::Api do
       stub_show_product_call
     end
 
-    let(:product) { Remote::Product.new(:identifier => 'rodent', :version => 'good', :arch => 'z42', :release_type => 'foo') }
+    let(:product) { Remote::Product.new(identifier: 'rodent', version: 'good', arch: 'z42', release_type: 'foo') }
 
     it 'is authenticated via basic auth' do
       payload = [
         '/connect/systems/products',
-        :auth => 'Basic: encodedgibberish',
-        :params => product.to_params
+        auth: 'Basic: encodedgibberish',
+        params: product.to_params
       ]
       Connection.any_instance.should_receive(:get)
         .with(*payload)
@@ -271,8 +271,8 @@ describe SUSE::Connect::Api do
 
       let(:products) do
         [
-          Remote::Product.new(:identifier => 'SLES', :version => '12', :arch => 'x86_64', :release_type => 'HP-CNB'),
-          Remote::Product.new(:identifier => 'SUSE-Cloud', :version => '7', :arch => 'x86_64', :release_type => nil)
+          Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64', release_type: 'HP-CNB'),
+          Remote::Product.new(identifier: 'SUSE-Cloud', version: '7', arch: 'x86_64', release_type: nil)
         ]
       end
 
@@ -281,8 +281,8 @@ describe SUSE::Connect::Api do
       it 'is authenticated via basic auth' do
         payload = [
           '/connect/systems/products/migrations',
-          :auth => 'Basic: encodedgibberish',
-          :params => query
+          auth: 'Basic: encodedgibberish',
+          params: query
         ]
         expect_any_instance_of(Connection).to receive(:post)
           .with(*payload)
@@ -329,7 +329,7 @@ describe SUSE::Connect::Api do
     it 'is authenticated via basic auth' do
       payload = [
         '/connect/systems',
-        :auth => 'Basic: encodedgibberish'
+        auth: 'Basic: encodedgibberish'
       ]
 
       Connection.any_instance.should_receive(:delete)
@@ -354,16 +354,16 @@ describe SUSE::Connect::Api do
 
     before do
       stub_update_call
-      System.stub(:hostname => 'connect')
-      System.stub(:hwinfo => 'hwinfo')
-      Zypper.stub(:distro_target => 'openSUSE-4.1-x86_64')
+      System.stub(hostname: 'connect')
+      System.stub(hwinfo: 'hwinfo')
+      Zypper.stub(distro_target: 'openSUSE-4.1-x86_64')
     end
 
     it 'is authenticated via basic auth' do
       payload = [
         '/connect/systems',
-        :auth => 'Basic: encodedgibberish', :params => { :hostname => 'connect', :hwinfo => 'hwinfo',
-                                                         :distro_target => 'openSUSE-4.1-x86_64' }
+        auth: 'Basic: encodedgibberish', params: { hostname: 'connect', hwinfo: 'hwinfo',
+                                                   distro_target: 'openSUSE-4.1-x86_64' }
       ]
       Connection.any_instance.should_receive(:put).with(*payload).and_call_original
       subject.new(client).update_system('Basic: encodedgibberish')

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -146,7 +146,7 @@ describe SUSE::Connect::Cli do
     context 'namespace option' do |variables|
       it '--namespace requires namespace' do
         expect(string_logger).to receive(:error).with('Please provide a namespace')
-        cli = subject.new('--namespace')
+        subject.new('--namespace')
       end
     end
 

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -143,6 +143,13 @@ describe SUSE::Connect::Cli do
       end
     end
 
+    context 'namespace option' do |variables|
+      it '--namespace requires namespace' do
+        expect(string_logger).to receive(:error).with('Please provide a namespace')
+        cli = subject.new('--namespace')
+      end
+    end
+
     context 'status subcommand' do
       it '--status calls json_product_status' do
         cli = subject.new(%w{--status})

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -86,7 +86,7 @@ describe SUSE::Connect::Client do
         api_response = double('api_response')
         api_response.stub(body: { 'login' => 'lg', 'password' => 'pw' })
         Api.any_instance.stub(announce_system: api_response)
-        subject.stub(token_auth: true)
+        subject.stub(token_auth: 'auth')
       end
 
       it 'calls underlying api' do
@@ -97,19 +97,19 @@ describe SUSE::Connect::Client do
 
       it 'forwards the optional parameter "distro_target" to the API' do
         optional_target = 'optional_target'
-        Api.any_instance.should_receive(:announce_system).with(true, optional_target, nil)
+        Api.any_instance.should_receive(:announce_system).with('auth', optional_target, nil)
         subject.announce_system(optional_target)
       end
 
       it 'forwards the optional parameter "namespace" to the API' do
         optional_namespace = 'namespace'
-        Api.any_instance.should_receive(:announce_system).with(true, optional_namespace, nil)
+        Api.any_instance.should_receive(:announce_system).with('auth', optional_namespace, nil)
         subject.announce_system(optional_namespace)
       end
 
       it 'reads instance_data_file and passes content the API' do
         instance_file_path = 'spec/fixtures/instance_data.xml'
-        Api.any_instance.should_receive(:announce_system).with(true, nil, File.read(instance_file_path))
+        Api.any_instance.should_receive(:announce_system).with('auth', nil, File.read(instance_file_path))
         subject.announce_system(nil, instance_file_path)
       end
 

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -95,10 +95,16 @@ describe SUSE::Connect::Client do
         subject.announce_system
       end
 
-      it 'passes the optional parameter "distro_target" to the API' do
+      it 'forwards the optional parameter "distro_target" to the API' do
         optional_target = 'optional_target'
         Api.any_instance.should_receive(:announce_system).with(true, optional_target, nil)
         subject.announce_system(optional_target)
+      end
+
+      it 'forwards the optional parameter "namespace" to the API' do
+        optional_namespace = 'namespace'
+        Api.any_instance.should_receive(:announce_system).with(true, optional_namespace, nil)
+        subject.announce_system(optional_namespace)
       end
 
       it 'reads instance_data_file and passes content the API' do
@@ -133,6 +139,13 @@ describe SUSE::Connect::Client do
         it 'forwards distro_target to api' do
           Api.any_instance.should_receive(:update_system).with('auth', 'my-distro-target', nil)
           subject.update_system('my-distro-target')
+        end
+
+        it 'forwards the optional parameter "namespace" to the API' do
+          optional_namespace = 'namespace'
+          Api.any_instance.should_receive(:update_system).with('auth', optional_namespace, nil)
+
+          subject.update_system(optional_namespace)
         end
 
         it 'forwards instance_data_file to api' do


### PR DESCRIPTION
Please review the following changes:
  * d2f15d5 ruby 1.9 hash style
  * db42282 pass namespace option to the API end point
  * d109389 ruby 1.9 hash style
  * befed92 pass branch name to the connect coockbook
  * 896647f stub token_auth and return a meaningful 'auth' string instead of true
  * 8a93f95 forward the optional parameter "namespace" to the API
  * 4aa2e9a add --namespace option