### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150609__5_suseconnect_status_fails_messily_if_system_deleted'

### DIFF
--- a/features/integration.feature
+++ b/features/integration.feature
@@ -28,9 +28,10 @@ Feature: SUSEConnect full stack integration testing
     And zypper should contain a repositories for sdk product
 
   Scenario: API response language check
-    Given I set the environment variables to
+    Given I set the environment variables to:
       | variable | value |
       | LANG     | de    |
+
     When I call SUSEConnect with '--regcode INVALID' arguments
     Then the exit status should be 67
 
@@ -49,7 +50,7 @@ Feature: SUSEConnect full stack integration testing
     When SUSEConnect library should respect API headers
 
   Scenario: System de-registration
-    When I cleanly deregister the system removing local credentials
+    When I deregister the system
     Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
 
     And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
@@ -63,21 +64,20 @@ Feature: SUSEConnect full stack integration testing
 
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments
-    Then I deregister the system only
+    Then I delete the system on SCC
+
     And I call SUSEConnect with '--status true' arguments
     Then the exit status should be 67
     And the output should contain:
     """
-    Not authorised. If using existing SCC credentials
+    Invalid system credentials, probably because the registered system was deleted in SUSE Customer Center.
     """
-    Then I remove local credentials
-
-  Scenario: client provides meaningful message in case of invalid reg-code
+  Scenario: Client provides meaningful message in case of invalid reg-code
     When I call SUSEConnect with '--regcode invalid' arguments
     Then the exit status should be 67
     And the output should contain:
     """
-    Provided registration code is not recognized by registration server.
+    Error: SCC returned 'No subscription with this registration code found
     """
 
   Scenario: Remove all registration leftovers

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -17,6 +17,7 @@ Feature: SUSEConnect full stack integration testing
     And zypper should contain a service for base product
     And zypper should contain a repositories for base product
 
+
   Scenario: Extension activation with regcode
     When I call SUSEConnect with '--regcode VALID --product sle-sdk/12/x86_64' arguments
     Then the exit status should be 0
@@ -26,6 +27,7 @@ Feature: SUSEConnect full stack integration testing
 
     And zypper should contain a service for sdk product
     And zypper should contain a repositories for sdk product
+
 
   Scenario: API response language check
     Given I set the environment variables to:
@@ -37,17 +39,21 @@ Feature: SUSEConnect full stack integration testing
 
     And the output should contain "Keine Subscription mit diesem Registrierungscode gefunden"
 
+
   ### SUSE::Connect library checks ###
   Scenario: Free extension activation
     When SUSEConnect library should be able to activate a free extension without regcode
     Then zypper should contain a service for wsm product
     And zypper should contain a repositories for wsm product
 
+
   Scenario: Product information (extensions)
     When SUSEConnect library should be able to retrieve the product information
 
+
   Scenario: API version check
     When SUSEConnect library should respect API headers
+
 
   Scenario: System de-registration
     When I deregister the system
@@ -62,6 +68,7 @@ Feature: SUSEConnect full stack integration testing
     And the output should not contain "SUSE_Linux_Enterprise_Software_Development_Kit_12_x86_64"
     And the output should not contain "Web_and_Scripting_Module_12_x86_64"
 
+
   Scenario: Error cleanly if system record was deleted on SCC only
     When I call SUSEConnect with '--regcode VALID' arguments
     Then I delete the system on SCC
@@ -72,13 +79,29 @@ Feature: SUSEConnect full stack integration testing
     """
     Invalid system credentials, probably because the registered system was deleted in SUSE Customer Center.
     """
+
+
+  Scenario: System cleanup
+    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should exist
+
+    And I run `zypper lr`
+    And the output should contain "SUSE_Linux_Enterprise_Server_12_x86_64"
+
+    When I call SUSEConnect with '--cleanup true' arguments
+
+    Then a file named "/etc/zypp/credentials.d/SCCcredentials" should not exist
+    And a file named "/etc/zypp/credentials.d/SUSE_Linux_Enterprise_Server_12_x86_64" should not exist
+
+
   Scenario: Client provides meaningful message in case of invalid reg-code
     When I call SUSEConnect with '--regcode invalid' arguments
     Then the exit status should be 67
     And the output should contain:
     """
-    Error: SCC returned 'No subscription with this registration code found
+    Error: Provided registration code is not recognized by registration server.
     """
+
 
   Scenario: Remove all registration leftovers
     When System cleanup

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -3,6 +3,10 @@ Then(/^Set regcode and url options$/) do
   @url = ENV['URL'] || SUSE::Connect::Config::DEFAULT_URL
 end
 
+Then(/^Prepare SUSEConnect client with a valid regcode/) do
+  step 'Set regcode and url options'
+  @client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
+end
 ### SUSEConnect cmd steps
 Then(/^I call SUSEConnect with '(.*)' arguments$/) do |args|
   options = Hash[*args.gsub('--', '').split(' ')]
@@ -63,30 +67,24 @@ end
 
 ### SUSEConnect library steps
 Then(/^SUSEConnect library should respect API headers$/) do
-  step 'Set regcode and url options'
+  step 'Prepare SUSEConnect client with a valid regcode'
 
-  client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
   response = SUSE::Connect::Api.new(client).announce_system("Token token=#{@regcode}")
-
   expect(response.headers['scc-api-version'].first).to eq(SUSE::Connect::Api::VERSION)
 end
 
 Then(/^I cleanly deregister the system removing local credentials$/) do
-  step 'Set regcode and url options'
-
-  client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
+  step 'Prepare SUSEConnect client with a valid regcode'
   client.deregister!
 end
 
 Then(/^I deregister the system only$/) do
-  step 'Set regcode and url options'
-  client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
+  step 'Prepare SUSEConnect client with a valid regcode'
   client.instance_eval { @api.deregister(system_auth) }
 end
 
 Then(/^I remove local credentials$/) do
-  step 'Set regcode and url options'
-  client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
+  step 'Prepare SUSEConnect client with a valid regcode'
   client.instance_eval { SUSE::Connect::System.remove_credentials }
 end
 
@@ -100,10 +98,9 @@ Then(/^SUSEConnect library should be able to activate a free extension without r
 end
 
 Then(/^SUSEConnect library should be able to retrieve the product information$/) do
-  step 'Set regcode and url options'
+  step 'Prepare SUSEConnect client with a valid regcode'
 
   remote_product = SUSE::Connect::Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64')
-  client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
   products = client.show_product(remote_product).extensions.map(&:friendly_name).sort
 
   products.each {|product| puts "- #{product}" }

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -7,7 +7,7 @@ Then(/^Prepare SUSEConnect client with a valid regcode/) do
   step 'Set regcode and url options'
   @client = SUSE::Connect::Client.new(SUSE::Connect::Config.new.merge!(url: @url, regcode: @regcode))
 end
-### SUSEConnect cmd steps
+
 Then(/^I call SUSEConnect with '(.*)' arguments$/) do |args|
   options = Hash[*args.gsub('--', '').split(' ')]
 
@@ -69,23 +69,23 @@ end
 Then(/^SUSEConnect library should respect API headers$/) do
   step 'Prepare SUSEConnect client with a valid regcode'
 
-  response = SUSE::Connect::Api.new(client).announce_system("Token token=#{@regcode}")
+  response = SUSE::Connect::Api.new(@client).announce_system("Token token=#{@regcode}")
   expect(response.headers['scc-api-version'].first).to eq(SUSE::Connect::Api::VERSION)
 end
 
-Then(/^I cleanly deregister the system removing local credentials$/) do
+Then(/^I deregister the system$/) do
   step 'Prepare SUSEConnect client with a valid regcode'
-  client.deregister!
+  @client.deregister!
 end
 
-Then(/^I deregister the system only$/) do
+Then(/^I delete the system on SCC$/) do
   step 'Prepare SUSEConnect client with a valid regcode'
-  client.instance_eval { @api.deregister(system_auth) }
+  @client.instance_eval { @api.deregister(system_auth) }
 end
 
 Then(/^I remove local credentials$/) do
   step 'Prepare SUSEConnect client with a valid regcode'
-  client.instance_eval { SUSE::Connect::System.remove_credentials }
+  @client.instance_eval { SUSE::Connect::System.remove_credentials }
 end
 
 Then(/^SUSEConnect library should be able to activate a free extension without regcode$/) do
@@ -101,7 +101,7 @@ Then(/^SUSEConnect library should be able to retrieve the product information$/)
   step 'Prepare SUSEConnect client with a valid regcode'
 
   remote_product = SUSE::Connect::Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64')
-  products = client.show_product(remote_product).extensions.map(&:friendly_name).sort
+  products = @client.show_product(remote_product).extensions.map(&:friendly_name).sort
 
   products.each {|product| puts "- #{product}" }
 

--- a/features/step_definition/integration_steps.rb
+++ b/features/step_definition/integration_steps.rb
@@ -19,6 +19,7 @@ Then(/^I call SUSEConnect with '(.*)' arguments$/) do |args|
   connect << " -r #{@regcode}" if options['regcode']
   connect << " -p #{options['product']}" if options['product']
   connect << ' -s' if options['status']
+  connect << ' --cleanup' if options['cleanup']
 
   puts "Calling '#{connect}' ..."
   step "I run `#{connect}`"

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -24,6 +24,8 @@ module SUSE
           Status.new(@config).print_product_statuses(:text)
         elsif @config.deregister
           Client.new(@config).deregister!
+        elsif @config.cleanup
+          System.cleanup!
         else
           if @config.instance_data_file && @config.url_default?
             log.error 'Please use --instance-data only in combination with --url pointing to your SMT server'
@@ -54,11 +56,9 @@ module SUSE
         case e.code
         when 401
           if System.credentials?
-            log.fatal 'Error: Not authorised. If using existing SCC credentials, they were not recognised,' \
-            ' probably because the registered system was unregistered or deleted.' \
+            log.fatal 'Error: Invalid system credentials, probably because the registered system was deleted in SUSE Customer Center.' \
             " Check #{@options[:url] || 'https://scc.suse.com'} whether your system appears there." \
-            ' If it does not, remove /etc/SUSEConnect, /etc/zypp/credentials.d/* and zypper services' \
-            ' using those credentials, and re-register this system.'
+            ' If it does not, please call SUSEConnect --cleanup and re-register this system.'
           else
             log.fatal 'Error: Provided registration code is not recognized by registration server.'
           end
@@ -147,6 +147,10 @@ module SUSE
 
         @opts.on('--write-config', 'write options to config file at /etc/SUSEConnect') do |opt|
           @options[:write_config] = true
+        end
+
+        @opts.on('--cleanup', 'remove old system credentials and all zypper services installed by SUSEConnect') do |opt|
+          @options[:cleanup] = true
         end
 
         @opts.separator ''

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -60,7 +60,7 @@ module SUSE
             ' If it does not, remove /etc/SUSEConnect, /etc/zypp/credentials.d/* and zypper services' \
             ' using those credentials, and re-register this system.'
           else
-            log.fatal 'Provided registration code is not recognized by registration server.'
+            log.fatal 'Error: Provided registration code is not recognized by registration server.'
           end
         else
           log.fatal "Error: SCC returned '#{e.message}' (#{e.code})"

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -34,8 +34,7 @@ module SUSE
       # @returns: Empty body and 204 status code
       def deregister!
         @api.deregister(system_auth)
-        System.remove_credentials
-        Zypper.remove_all_suse_services
+        System.cleanup
       end
 
       # Announce system via SCC/Registration Proxy

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -34,7 +34,7 @@ module SUSE
       # @returns: Empty body and 204 status code
       def deregister!
         @api.deregister(system_auth)
-        System.cleanup
+        System.cleanup!
       end
 
       # Announce system via SCC/Registration Proxy

--- a/lib/suse/connect/system.rb
+++ b/lib/suse/connect/system.rb
@@ -40,6 +40,11 @@ module SUSE
           File.delete Credentials.system_credentials_file if credentials?
         end
 
+        def cleanup
+          System.remove_credentials
+          Zypper.remove_all_suse_services
+        end
+
         def add_service(service)
           raise ArgumentError, 'only Remote::Service accepted' unless service.is_a? Remote::Service
           Zypper.remove_service(service.name)

--- a/lib/suse/connect/system.rb
+++ b/lib/suse/connect/system.rb
@@ -40,7 +40,7 @@ module SUSE
           File.delete Credentials.system_credentials_file if credentials?
         end
 
-        def cleanup
+        def cleanup!
           System.remove_credentials
           Zypper.remove_all_suse_services
         end

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -20,7 +20,7 @@ module SUSE
         # Returns an array of all installed products, in which every product is
         # presented as a hash.
         def installed_products
-          zypper_out = call('--xmlout --non-interactive products -i', false)
+          zypper_out = call('--no-refresh --xmlout --non-interactive products -i', false)
           xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
           ary_of_products_hashes = xml_doc.root.elements['product-list'].elements.map(&:to_hash)
           ary_of_products_hashes.map {|hash| Product.new(hash) }

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -47,7 +47,7 @@ describe SUSE::Connect::Cli do
           response = Net::HTTPResponse.new('1.1', 401, 'Test')
           allow(System).to receive(:credentials?).and_return false
           expect_any_instance_of(Client).to receive(:register!).and_raise ApiError.new(response)
-          expect(string_logger).to receive(:fatal).with('Provided registration code is not recognized by registration server.')
+          expect(string_logger).to receive(:fatal).with('Error: Provided registration code is not recognized by registration server.')
           cli.execute!
         end
       end

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -37,7 +37,7 @@ describe SUSE::Connect::Cli do
           response = Net::HTTPResponse.new('1.1', 401, 'Test')
           allow(System).to receive(:credentials?).and_return true
           expect_any_instance_of(Client).to receive(:register!).and_raise ApiError.new(response)
-          expect(string_logger).to receive(:fatal).with(match(/Error: Not authorised./))
+          expect(string_logger).to receive(:fatal).with(match(/Error: Invalid system credentials/))
           cli.execute!
         end
       end
@@ -139,6 +139,14 @@ describe SUSE::Connect::Cli do
       it '--de-register calls deregister! method' do
         cli = subject.new(%w{--de-register})
         expect_any_instance_of(Client).to receive(:deregister!)
+        cli.execute!
+      end
+    end
+
+    context 'cleanup command' do
+      it '--cleanup calls Systems cleanup! method' do
+        cli = subject.new(%w{--cleanup})
+        expect(System).to receive(:cleanup!)
         cli.execute!
       end
     end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -406,11 +406,10 @@ describe SUSE::Connect::Client do
     end
 
     it 'calls underlying api and removes credentials file' do
-      expect(Zypper).to receive(:remove_all_suse_services).and_return(true)
-      expect(System).to receive(:remove_credentials).and_return(true)
       expect(subject.api).to receive(:deregister).with('Basic: encodedstring').and_return stubbed_response
+      expect(System).to receive(:cleanup).and_return(true)
 
-      subject.deregister!.should be true
+      subject.deregister!
     end
   end
 

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -407,7 +407,7 @@ describe SUSE::Connect::Client do
 
     it 'calls underlying api and removes credentials file' do
       expect(subject.api).to receive(:deregister).with('Basic: encodedstring').and_return stubbed_response
-      expect(System).to receive(:cleanup).and_return(true)
+      expect(System).to receive(:cleanup!).and_return(true)
 
       subject.deregister!
     end

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -132,6 +132,15 @@ describe SUSE::Connect::System do
     end
   end
 
+  describe '.cleanup' do
+    it 'removes system credentials and zypper services which were added by SUSEConnect' do
+      expect(Zypper).to receive(:remove_all_suse_services).and_return(true)
+      expect(System).to receive(:remove_credentials).and_return(true)
+
+      subject.cleanup
+    end
+  end
+
   describe '.hostname' do
     context :hostname_detected do
       it 'returns hostname' do

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -132,12 +132,12 @@ describe SUSE::Connect::System do
     end
   end
 
-  describe '.cleanup' do
+  describe '.cleanup!' do
     it 'removes system credentials and zypper services which were added by SUSEConnect' do
       expect(Zypper).to receive(:remove_all_suse_services).and_return(true)
       expect(System).to receive(:remove_credentials).and_return(true)
 
-      subject.cleanup
+      subject.cleanup!
     end
   end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -22,7 +22,7 @@ describe SUSE::Connect::Zypper do
         let(:xml) { File.read('spec/fixtures/product_valid_sle11sp3.xml') }
 
         before do
-          args = 'zypper --xmlout --non-interactive products -i'
+          args = 'zypper --no-refresh --xmlout --non-interactive products -i'
           Open3.should_receive(:capture3).with(shared_env_hash, args).and_return([xml, '', status])
         end
 
@@ -51,7 +51,7 @@ describe SUSE::Connect::Zypper do
         let(:xml) { File.read('spec/fixtures/product_valid_sle12sp0.xml') }
 
         before do
-          args = 'zypper --xmlout --non-interactive products -i'
+          args = 'zypper --no-refresh --xmlout --non-interactive products -i'
           Open3.should_receive(:capture3).with(shared_env_hash, args).and_return([xml, '', status])
         end
 


### PR DESCRIPTION
Please review the following changes:
  * f102573 add test case for SUSEConnect --cleanup
  * 76661bd fix integrational tests
  * 8fcddc3 re-factor integration steps
  * 6d41596 add --cleanup option and adapt error message
  * ae9aeb7 add bang to the cleanup method
  * 8cd86ae cleanup system after de-registration
  * 5bc0529 add cleanup method to the System class
  * f058a0b add 'Error' to the error message string
  * 7353a18 iadd --no-refresh to prevent a repo/service refresh on the products call