### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150702_replace_defaults_method_returning_the_hash_with_a_constants'

### DIFF
--- a/lib/suse/connect.rb
+++ b/lib/suse/connect.rb
@@ -11,12 +11,12 @@ module SUSE
     require 'suse/connect/credentials'
     require 'suse/connect/config'
     require 'suse/connect/api'
-    require 'suse/connect/yast'
     require 'suse/connect/ssl_certificate'
     require 'suse/connect/status'
     require 'suse/connect/zypper'
     require 'suse/connect/zypper/product_status'
     require 'suse/connect/hwinfo/base'
+    require 'suse/connect/yast'
 
     # Holding all the object classes received from registration server
     module Remote

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -5,21 +5,15 @@ module SUSE
     # YaST call this class from:
     # https://github.com/yast/yast-registration/blob/master/src/lib/registration/registration.rb
     class YaST
+      # Define a constants which point to the constants used in SUSEConnect
+      DEFAULT_CONFIG_FILE = SUSE::Connect::Config::DEFAULT_CONFIG_FILE
+      DEFAULT_URL = SUSE::Connect::Config::DEFAULT_URL
+      DEFAULT_CREDENTIALS_DIR = SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR
+      GLOBAL_CREDENTIALS_FILE = SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
+      SERVER_CERT_FILE = SUSE::Connect::SSLCertificate::SERVER_CERT_FILE
+      UPDATE_CERTIFICATES = SUSE::Connect::SSLCertificate::UPDATE_CERTIFICATES
+
       class << self
-
-        # Returns a hash containing default configuration values.
-        # Keys: :config_file_path, :scc_url, :server_cert_file_path, :update_certificates_script_path, :credentials_dir_path, :global_credentials_file_path
-        # @return [Hash]
-        def defaults
-          { config_file_path: SUSE::Connect::Config::DEFAULT_CONFIG_FILE,
-            scc_url: SUSE::Connect::Config::DEFAULT_URL,
-            server_cert_file_path: SUSE::Connect::SSLCertificate::SERVER_CERT_FILE,
-            update_certificates_script_path: SUSE::Connect::SSLCertificate::UPDATE_CERTIFICATES,
-            credentials_dir_path: SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR,
-            global_credentials_file_path: SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
-          }
-        end
-
         # Announces the system to SCC / the registration server.
         # Expects a token / regcode to identify the correct subscription.
         # Additionally, distro_target should be set to avoid calls to Zypper.

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -4,20 +4,14 @@ describe SUSE::Connect::YaST do
 
   subject { SUSE::Connect::YaST }
 
-  describe '#defaults' do
-    it 'returns expected keys' do
-      expect(subject.defaults).to have_key(:config_file_path)
-      expect(subject.defaults).to have_key(:scc_url)
-      expect(subject.defaults).to have_key(:server_cert_file_path)
-      expect(subject.defaults).to have_key(:update_certificates_script_path)
-      expect(subject.defaults).to have_key(:credentials_dir_path)
-      expect(subject.defaults).to have_key(:global_credentials_file_path)
-      expect(subject.defaults[:config_file_path]).to eq SUSE::Connect::Config::DEFAULT_CONFIG_FILE
-      expect(subject.defaults[:scc_url]).to eq SUSE::Connect::Config::DEFAULT_URL
-      expect(subject.defaults[:server_cert_file_path]).to eq SUSE::Connect::SSLCertificate::SERVER_CERT_FILE
-      expect(subject.defaults[:update_certificates_script_path]).to eq SUSE::Connect::SSLCertificate::UPDATE_CERTIFICATES
-      expect(subject.defaults[:credentials_dir_path]).to eq SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR
-      expect(subject.defaults[:global_credentials_file_path]).to eq SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
+  describe 'YaST CONSTANTS' do
+    it 'checks the constants definition and their values' do
+      expect(subject::DEFAULT_CONFIG_FILE).to eq SUSE::Connect::Config::DEFAULT_CONFIG_FILE
+      expect(subject::DEFAULT_URL).to eq SUSE::Connect::Config::DEFAULT_URL
+      expect(subject::DEFAULT_CREDENTIALS_DIR).to eq SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR
+      expect(subject::GLOBAL_CREDENTIALS_FILE).to eq SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
+      expect(subject::SERVER_CERT_FILE).to eq SUSE::Connect::SSLCertificate::SERVER_CERT_FILE
+      expect(subject::UPDATE_CERTIFICATES).to eq SUSE::Connect::SSLCertificate::UPDATE_CERTIFICATES
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ end
 
 require 'rspec'
 require 'ap'
+require 'byebug'
 require 'webmock/rspec'
 require 'suse/connect'
 


### PR DESCRIPTION
Please review the following changes:
  * 868a692 replace defaults method returning the hash with a constants
  * 357a281 require yast class at the end because of the constant definitions
  * 368cdaa allow byebug usage in tests