### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150714_add_activated_products_method_and_return_plain_openstruct_objects'

### DIFF
--- a/lib/suse/connect.rb
+++ b/lib/suse/connect.rb
@@ -16,6 +16,7 @@ module SUSE
     require 'suse/connect/zypper/product_status'
     require 'suse/connect/hwinfo/base'
     require 'suse/connect/product'
+    require 'suse/connect/migration'
     require 'suse/connect/yast'
 
     # Holding all the object classes received from registration server

--- a/lib/suse/connect/core_ext/hash_refinement.rb
+++ b/lib/suse/connect/core_ext/hash_refinement.rb
@@ -1,0 +1,14 @@
+module SUSE
+  module Connect
+    module CoreExt
+      # Extends a Hash class with a to_openstruct method
+      module HashRefinement
+        refine ::Hash do
+          def to_openstruct
+            OpenStruct.new self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/suse/connect/credentials.rb
+++ b/lib/suse/connect/credentials.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'pathname'
+require 'suse/toolkit/cast'
 
 module SUSE
   module Connect
@@ -11,6 +12,7 @@ module SUSE
     # (Reading and writing (#read, #write), reading/writing the attributes (#file, #username, #password))
     class Credentials
       include Logger
+      include SUSE::Toolkit::Cast
 
       DEFAULT_CREDENTIALS_DIR = '/etc/zypp/credentials.d'
       GLOBAL_CREDENTIALS_FILE = File.join(DEFAULT_CREDENTIALS_DIR, 'SCCcredentials')
@@ -62,6 +64,11 @@ module SUSE
         contents[:password] = '[FILTERED]'.inspect
         contents[:file]     = file.inspect
         format('#<%{class}:%{id} @username=%{username}, @password=%{password}, @file=%{file}>', contents)
+      end
+
+      # Returns a hash representation of the object
+      def to_h
+        { username: username, password: password, file: file }
       end
 
       private

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -2,6 +2,7 @@ module SUSE
   module Connect
 
     # Migration class is an abstraction layer for SLE migration script
+    # Migration script call this class from: https://github.com/nadvornik/zypper-migration/blob/master/zypper-migration
     class Migration
       class << self
         # Returns installed and activated products on the system

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -25,7 +25,6 @@ module SUSE
           SUSE::Connect::Zypper.remove_service(service_name)
         end
 
-
       end
     end
 

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -7,10 +7,10 @@ module SUSE
       class << self
         # Returns installed and activated products on the system
         # @param [Hash] client_params parameters to instantiate {Client}
-        # @return [Array <Connect::Product>] the list of system products
+        # @return [Array <OpenStruct>] the list of system products
         def system_products(client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
-          Status.new(config).system_products
+          Status.new(config).system_products.map(&:to_openstruct)
         end
 
         # Forwards the service which should be added with zypper

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -1,0 +1,33 @@
+module SUSE
+  module Connect
+
+    # Migration class is an abstraction layer for SLE migration script
+    class Migration
+      class << self
+        # Returns installed and activated products on the system
+        # @param [Hash] client_params parameters to instantiate {Client}
+        # @return [Array <Connect::Product>] the list of system products
+        def system_products(client_params = {})
+          config = SUSE::Connect::Config.new.merge!(client_params)
+          Status.new(config).system_products
+        end
+
+        # Forwards the service which should be added with zypper
+        # @param [String] service_url the url from the service to add
+        # @param [String] service_name the name of the service to add
+        def add_service(service_url, service_name)
+          SUSE::Connect::Zypper.add_service(service_url, service_name)
+        end
+
+        # Forwards the service names which should be removed with zypper
+        # @param [String] service_name the name of the service to remove
+        def remove_service(service_name)
+          SUSE::Connect::Zypper.remove_service(service_name)
+        end
+
+
+      end
+    end
+
+  end
+end

--- a/lib/suse/connect/product.rb
+++ b/lib/suse/connect/product.rb
@@ -1,7 +1,11 @@
+require 'suse/toolkit/cast'
+
 module SUSE
   module Connect
     # Product class is a common class to represent all products
     class Product < OpenStruct
+      include SUSE::Toolkit::Cast
+
       def self.transform(old_product)
         product = Product.new
         product.identifier = old_product.identifier

--- a/lib/suse/connect/remote/product.rb
+++ b/lib/suse/connect/remote/product.rb
@@ -1,4 +1,5 @@
 require 'suse/toolkit/product_equality'
+require 'suse/toolkit/cast'
 
 # Product as sent from registration server
 #
@@ -6,6 +7,7 @@ require 'suse/toolkit/product_equality'
 # Reads attributes (i.e. calls #identifier, #version, #arch)
 class SUSE::Connect::Remote::Product < SUSE::Connect::Remote::ServerDrivenModel
   include SUSE::Toolkit::ProductEquality
+  include SUSE::Toolkit::Cast
 
   def initialize(product_hash)
     super

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -85,13 +85,13 @@ module SUSE
         # products for the system that are extensions to the specified product.
         # Gets the list from SCC and returns them.
         #
-        # @param product [Remote::Product] product to list extensions for
+        # @param product [OpenStruct] product to list extensions for
         # @param [Hash] client_params parameters to instantiate {Client}
         #
-        # @return [Product] {Product}s from registration server with all extensions included
+        # @return [OpenStruct] {Product}s from registration server with all extensions included
         def show_product(product, client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
-          Client.new(config).show_product(product)
+          Client.new(config).show_product(product).to_openstruct
         end
 
         # Checks if the given product is already activated in SCC

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -68,6 +68,18 @@ module SUSE
           Client.new(config).upgrade_product(product)
         end
 
+        # Creates the system or zypper service credentials file with given login and password.
+        # Returns the number of bytes written.
+        #
+        # @param [String] system login - return value of announce_system method
+        # @param [String] system password - return value of announce_system method
+        # @param [String] credentials_file - defaults to /etc/zypp/credentials.d/SCCcredentials
+        #
+        # @return [Integer] number of written bytes
+        def create_credentials_file(login, password, credentials_file=GLOBAL_CREDENTIALS_FILE)
+          Credentials.new(login, password, credentials_file).write
+        end
+
         # Lists all available products for a system.
         # Accepts a parameter product_ident, which scopes the result set down to all
         # products for the system that are extensions to the specified product.

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -68,6 +68,16 @@ module SUSE
           Client.new(config).upgrade_product(product)
         end
 
+        # Reads credentials file.
+        # Returns the credentials object with login, password and credentials file
+        #
+        # @param [String] Path to credentials file - defaults to /etc/zypp/credentials.d/SCCcredentials
+        #
+        # @return [OpenStruct] Credentials object as openstruct
+        def credentials(credentials_file = GLOBAL_CREDENTIALS_FILE)
+          Credentials.read(credentials_file).to_openstruct
+        end
+
         # Creates the system or zypper service credentials file with given login and password.
         # Returns the number of bytes written.
         #
@@ -88,7 +98,7 @@ module SUSE
         # @param product [OpenStruct] product to list extensions for
         # @param [Hash] client_params parameters to instantiate {Client}
         #
-        # @return [OpenStruct] {Product}s from registration server with all extensions included
+        # @return [OpenStruct] {Product} from registration server with all extensions included
         def show_product(product, client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
           Client.new(config).show_product(product).to_openstruct

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -92,6 +92,14 @@ module SUSE
           status(client_params).activated_products.include?(product)
         end
 
+        # Returns activated products on the system
+        # @param [Hash] client_params parameters to instantiate {Client}
+        # @return [Array <OpenStruct>] the list of activated products
+        def activated_products(client_params = {})
+          config = SUSE::Connect::Config.new.merge!(client_params)
+          Status.new(config).activated_products.map(&:to_openstruct)
+        end
+
         # Lists all available upgrade paths for a given list of products
         # Accepts an array of products, and returns an array of possible
         # upgrade paths. An upgrade path is a list of products that may

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -76,7 +76,7 @@ module SUSE
         # @param [String] credentials_file - defaults to /etc/zypp/credentials.d/SCCcredentials
         #
         # @return [Integer] number of written bytes
-        def create_credentials_file(login, password, credentials_file=GLOBAL_CREDENTIALS_FILE)
+        def create_credentials_file(login, password, credentials_file = GLOBAL_CREDENTIALS_FILE)
           Credentials.new(login, password, credentials_file).write
         end
 

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -137,27 +137,6 @@ module SUSE
           Client.new(config).system_migrations(products)
         end
 
-        # Returns installed and activated products on the system
-        # @param [Hash] client_params parameters to instantiate {Client}
-        # @return [Array <Connect::Product>] the list of system products
-        def system_products(client_params = {})
-          config = SUSE::Connect::Config.new.merge!(client_params)
-          Status.new(config).system_products
-        end
-
-        # Forwards the service which should be added with zypper
-        # @param [String] service_url the url from the service to add
-        # @param [String] service_name the name of the service to add
-        def add_service(service_url, service_name)
-          SUSE::Connect::Zypper.add_service(service_url, service_name)
-        end
-
-        # Forwards the service names which should be removed with zypper
-        # @param [String] service_name the name of the service to remove
-        def remove_service(service_name)
-          SUSE::Connect::Zypper.remove_service(service_name)
-        end
-
         # Writes the config file with the given parameters, overwriting any existing contents
         # Only persistent connection parameters (url, insecure) are written by this method
         # Regcode, language, debug etc are not

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -43,7 +43,7 @@ module SUSE
         # Requires a token / regcode except for free products/extensions.
         # Returns a service object for the activated product.
         #
-        # @param [Remote::Product] product with identifier, arch and version defined
+        # @param [OpenStruct] product with identifier, arch and version defined
         # @param [Hash] client_params parameters to instantiate {Client}
         # @param [String] email email to which this activation should be connected to
         #
@@ -59,7 +59,7 @@ module SUSE
         # product was registered with, or be a free product.
         # Returns a service object for the new activated product.
         #
-        # @param [Remote::Product] product with identifier, arch and version defined
+        # @param [OpenStruct] product with identifier, arch and version defined
         # @param [Hash] client_params parameters to instantiate {Client}
         #
         # @return [Service] Service
@@ -95,7 +95,7 @@ module SUSE
         # products for the system that are extensions to the specified product.
         # Gets the list from SCC and returns them.
         #
-        # @param product [OpenStruct] product to list extensions for
+        # @param [OpenStruct] product to list extensions for
         # @param [Hash] client_params parameters to instantiate {Client}
         #
         # @return [OpenStruct] {Product} from registration server with all extensions included
@@ -105,13 +105,13 @@ module SUSE
         end
 
         # Checks if the given product is already activated in SCC
-        # @param product [Remote::Product] product
+        # @param [OpenStruct] product
         # @param [Hash] client_params parameters to instantiate {Client}
         #
         # @return Boolean
         def product_activated?(product, client_params = {})
           return false unless SUSE::Connect::System.credentials?
-          status(client_params).activated_products.include?(product)
+          status(client_params).activated_products.map(&:to_openstruct).include?(product)
         end
 
         # Returns activated products on the system
@@ -127,14 +127,14 @@ module SUSE
         # upgrade paths. An upgrade path is a list of products that may
         # be upgraded.
         #
-        # @param [Array <Remote::Product>] the list of currently installed {Product}s in the system
+        # @param [Array <OpenStruct>] the list of currently installed {Product}s in the system
         # @param [Hash] client_params parameters to instantiate {Client}
         #
-        # @return [Array <Array <Remote::Product>>] the list of possible upgrade paths for the given {Product}s,
+        # @return [Array <Array <OpenStruct>>] the list of possible upgrade paths for the given {Product}s,
         #   where an upgrade path is an array of Remote::Product object.
         def system_migrations(products, client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
-          Client.new(config).system_migrations(products)
+          Client.new(config).system_migrations(products).map {|a| a.map(&:to_openstruct) }
         end
 
         # Writes the config file with the given parameters, overwriting any existing contents

--- a/lib/suse/toolkit/cast.rb
+++ b/lib/suse/toolkit/cast.rb
@@ -1,0 +1,28 @@
+module SUSE
+  module Toolkit
+    # Object conversion
+    module Cast
+      def to_openstruct
+        attributes = self.attributes
+        attributes.each do |key,value|
+          attributes[key] = value.map{|v| v.to_openstruct } if value.is_a?(Array) && value.any?{ |v| v.is_a?(Hash) }
+        end
+        OpenStruct.new(attributes)
+      end
+
+      def attributes
+        attributes = self.to_h
+        attributes.each do |k,v|
+          attributes[k] = v.map(&:to_h) if v.is_a?(Array) && v.any?{ |v| v.is_a?(OpenStruct) }
+        end
+        attributes
+      end
+    end
+  end
+end
+
+class Hash
+  def to_openstruct
+    OpenStruct.new self
+  end
+end

--- a/lib/suse/toolkit/cast.rb
+++ b/lib/suse/toolkit/cast.rb
@@ -12,8 +12,8 @@ module SUSE
 
       def attributes
         attributes = to_h
-        attributes.each do |k, v|
-          attributes[k] = v.map(&:to_h) if v.is_a?(Array) && v.any? {|v| v.is_a?(OpenStruct) }
+        attributes.each do |key, value|
+          attributes[key] = value.map(&:to_h) if value.is_a?(Array) && value.any? {|v| v.is_a?(OpenStruct) }
         end
         attributes
       end
@@ -21,6 +21,7 @@ module SUSE
   end
 end
 
+# Extends a Hash class with a to_openstruct method
 class Hash
   def to_openstruct
     OpenStruct.new self

--- a/lib/suse/toolkit/cast.rb
+++ b/lib/suse/toolkit/cast.rb
@@ -4,16 +4,16 @@ module SUSE
     module Cast
       def to_openstruct
         attributes = self.attributes
-        attributes.each do |key,value|
-          attributes[key] = value.map{|v| v.to_openstruct } if value.is_a?(Array) && value.any?{ |v| v.is_a?(Hash) }
+        attributes.each do |key, value|
+          attributes[key] = value.map {|v| v.to_openstruct } if value.is_a?(Array) && value.any? {|v| v.is_a?(Hash) }
         end
         OpenStruct.new(attributes)
       end
 
       def attributes
-        attributes = self.to_h
-        attributes.each do |k,v|
-          attributes[k] = v.map(&:to_h) if v.is_a?(Array) && v.any?{ |v| v.is_a?(OpenStruct) }
+        attributes = to_h
+        attributes.each do |k, v|
+          attributes[k] = v.map(&:to_h) if v.is_a?(Array) && v.any? {|v| v.is_a?(OpenStruct) }
         end
         attributes
       end

--- a/lib/suse/toolkit/cast.rb
+++ b/lib/suse/toolkit/cast.rb
@@ -1,3 +1,6 @@
+require 'suse/connect/core_ext/hash_refinement'
+using SUSE::Connect::CoreExt::HashRefinement
+
 module SUSE
   module Toolkit
     # Object conversion
@@ -18,12 +21,5 @@ module SUSE
         attributes
       end
     end
-  end
-end
-
-# Extends a Hash class with a to_openstruct method
-class Hash
-  def to_openstruct
-    OpenStruct.new self
   end
 end

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -127,8 +127,8 @@ describe SUSE::Connect::Api do
       it 'holds expected structure' do
         Connection.any_instance.should_receive(:get).with('/connect/systems/services', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_services('basic_auth_string').body
-        result.should be_kind_of Array
-        result.first.keys.should eq %w{id name product}
+        expect(result).to be_kind_of Array
+        expect(result.first.keys).to match_array %w{id name product}
       end
     end
 
@@ -145,10 +145,11 @@ describe SUSE::Connect::Api do
       it 'holds expected structure' do
         Connection.any_instance.should_receive(:get).with('/connect/systems/subscriptions', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_subscriptions('basic_auth_string').body
-        result.should be_kind_of Array
+        expect(result).to be_kind_of Array
+
         attr_ary = %w{id regcode name type status starts_at expires_at}
         attr_ary += %w{system_limit systems_count virtual_count product_classes systems product_ids}
-        result.first.keys.should eq attr_ary
+        expect(result.first.keys).to eq attr_ary
       end
     end
 
@@ -165,9 +166,8 @@ describe SUSE::Connect::Api do
       it 'holds expected structure' do
         Connection.any_instance.should_receive(:get).with('/connect/systems/activations', auth: 'basic_auth_string').and_call_original
         result = subject.new(client).system_activations('basic_auth_string').body
-        result.should be_kind_of Array
-        attr_ary = %w{id regcode type status starts_at expires_at system_id service}
-        expect(result.first.keys).to eq attr_ary
+        expect(result).to be_kind_of Array
+        expect(result.first.keys).to eq %w{id regcode type status starts_at expires_at system_id service}
       end
     end
   end
@@ -195,7 +195,7 @@ describe SUSE::Connect::Api do
         .with(api_endpoint, auth: system_auth, params: payload)
         .and_call_original
       response = subject.new(client).activate_product(system_auth, product)
-      response.body['name'].should eq 'SUSE_Linux_Enterprise_Server_12_x86_64'
+      expect(response.body['name']).to eq 'SUSE_Linux_Enterprise_Server_12_x86_64'
     end
 
     it 'allows to add an optional parameter "email"' do
@@ -218,7 +218,7 @@ describe SUSE::Connect::Api do
         .with(api_endpoint, auth: system_auth, params: product.to_params)
         .and_call_original
       response = subject.new(client).upgrade_product(system_auth, product)
-      response.body['sources'].keys.first.should include('SUSE')
+      expect(response.body['sources'].keys.first).to include('SUSE')
     end
   end
 
@@ -243,12 +243,12 @@ describe SUSE::Connect::Api do
 
     it 'responds with proper status code' do
       response = subject.new(client).show_product('Basic: encodedgibberish', product)
-      response.code.should eq 200
+      expect(response.code).to eq 200
     end
 
     it 'returns array of extensions' do
       body = subject.new(client).show_product('Basic: encodedgibberish', product).body
-      body.should be_kind_of Hash
+      expect(body).to be_kind_of Hash
     end
   end
 
@@ -329,12 +329,12 @@ describe SUSE::Connect::Api do
 
     it 'responds with proper status code' do
       response = subject.new(client).deregister('Basic: encodedgibberish')
-      response.code.should eq 204
+      expect(response.code).to eq 204
     end
 
     it 'returns empty body' do
       body = subject.new(client).deregister('Basic: encodedgibberish').body
-      body.should be_nil
+      expect(body).to be_nil
     end
   end
 
@@ -358,12 +358,12 @@ describe SUSE::Connect::Api do
 
     it 'responds with proper status code' do
       response = subject.new(client).update_system('Basic: encodedgibberish')
-      response.code.should eq 204
+      expect(response.code).to eq 204
     end
 
     it 'returns empty body' do
       body = subject.new(client).update_system('Basic: encodedgibberish').body
-      body.should be_nil
+      expect(body).to be_nil
     end
 
     it 'sets namespace data in payload' do

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -188,31 +188,31 @@ describe SUSE::Connect::Cli do
     it 'sets token options' do
       argv = %w{-r matoken}
       cli = subject.new(argv)
-      cli.options[:token].should eq 'matoken'
+      expect(cli.options[:token]).to eq 'matoken'
     end
 
     it 'sets product options' do
       argv = %w{--product sles/12/i386}
       cli = subject.new(argv)
-      cli.options[:product].should eq Remote::Product.new(identifier: 'sles', version: '12', arch: 'i386')
+      expect(cli.options[:product]).to eq Remote::Product.new(identifier: 'sles', version: '12', arch: 'i386')
     end
 
     it 'sets token options' do
       argv = %w{--regcode matoken}
       cli = subject.new(argv)
-      cli.options[:token].should eq 'matoken'
+      expect(cli.options[:token]).to eq 'matoken'
     end
 
     it 'sets email options' do
       argv = %w{--email me@hotmail.com}
       cli = subject.new(argv)
-      cli.options[:email].should eq 'me@hotmail.com'
+      expect(cli.options[:email]).to eq 'me@hotmail.com'
     end
 
     it 'sets url options' do
       argv = %w{--url test}
       cli = subject.new(argv)
-      cli.options[:url].should eq 'test'
+      expect(cli.options[:url]).to eq 'test'
     end
 
     it 'puts version on version flag' do
@@ -230,19 +230,19 @@ describe SUSE::Connect::Cli do
     it 'sets verbose options' do
       argv = %w{--debug}
       cli = subject.new(argv)
-      cli.options[:debug].should be true
+      expect(cli.options[:debug]).to be true
     end
 
     it 'sets deregister option' do
       argv = %w{--de-register}
       cli = subject.new(argv)
-      cli.options[:deregister].should be true
+      expect(cli.options[:deregister]).to be true
     end
 
     it 'sets root option' do
       argv = %w{--root /path/to/root}
       subject.new(argv)
-      SUSE::Connect::System.filesystem_root.should eq '/path/to/root'
+      expect(SUSE::Connect::System.filesystem_root).to eq '/path/to/root'
       SUSE::Connect::System.filesystem_root = nil
     end
 
@@ -254,7 +254,7 @@ describe SUSE::Connect::Cli do
     it 'sets write_config option' do
       argv = %w{--write-config}
       cli = subject.new(argv)
-      cli.options[:write_config].should be true
+      expect(cli.options[:write_config]).to be true
     end
   end
 

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -13,7 +13,7 @@ describe SUSE::Connect::Client do
   describe '.new' do
     context :empty_opts do
       it 'should set url to default_url' do
-        subject.config.url.should eq SUSE::Connect::Config::DEFAULT_URL
+        expect(subject.config.url).to eq SUSE::Connect::Config::DEFAULT_URL
       end
     end
 
@@ -196,8 +196,8 @@ describe SUSE::Connect::Client do
 
     it 'returns service object' do
       service = subject.activate_product(product_ident)
-      service.name.should eq 'kinkat'
-      service.url.should eq 'kinkaturl'
+      expect(service.name).to eq 'kinkat'
+      expect(service.url).to eq 'kinkaturl'
     end
   end
 
@@ -223,8 +223,8 @@ describe SUSE::Connect::Client do
 
     it 'returns service object' do
       service = subject.upgrade_product(product_ident)
-      service.name.should eq 'tongobongo'
-      service.url.should eq 'tongobongourl'
+      expect(service.name).to eq 'tongobongo'
+      expect(service.url).to eq 'tongobongourl'
     end
   end
 
@@ -310,7 +310,7 @@ describe SUSE::Connect::Client do
 
     it 'returns array of extension products returned from api' do
       subject.api.should_receive(:show_product).with('Basic: encodedstring', product).and_return stubbed_response
-      subject.show_product(product).should be_kind_of Remote::Product
+      expect(subject.show_product(product)).to be_kind_of Remote::Product
     end
   end
 

--- a/spec/connect/config_spec.rb
+++ b/spec/connect/config_spec.rb
@@ -111,7 +111,7 @@ describe SUSE::Connect::Config do
 
     context '#write' do
       it 'writes configuration settings to YAML file' do
-        File.should_receive(:write).with(config_file, config.to_yaml).and_return(0)
+        expect(File).to receive(:write).with(config_file, config.to_yaml).and_return(0)
         config.write!
       end
     end

--- a/spec/connect/connection_spec.rb
+++ b/spec/connect/connection_spec.rb
@@ -49,8 +49,8 @@ describe SUSE::Connect::Connection do
       it 'logs the error in the default verify_callack and returns failure' do
         context = double
         expect(context).to receive(:error_string).and_return('ERROR')
-        context.stub_chain(:current_cert, :issuer).and_return('ISSUER')
-        context.stub_chain(:current_cert, :subject).and_return('SUBJECT')
+        allow(context).to receive_message_chain(:current_cert, :issuer).and_return('ISSUER')
+        allow(context).to receive_message_chain(:current_cert, :subject).and_return('SUBJECT')
 
         logger = double
         expect(logger).to receive(:error) do |msg|

--- a/spec/connect/connection_spec.rb
+++ b/spec/connect/connection_spec.rb
@@ -9,12 +9,12 @@ describe SUSE::Connect::Connection do
     end
 
     it 'stores http object' do
-      secure_connection.http.should be_kind_of Net::HTTP
+      expect(secure_connection.http).to be_kind_of Net::HTTP
     end
 
     it 'parse passed endpoint to http port and host' do
-      secure_connection.http.port.should eq 443
-      secure_connection.http.address.should eq 'example.com'
+      expect(secure_connection.http.port).to eq 443
+      expect(secure_connection.http.address).to eq 'example.com'
     end
 
     context :proxy_detected do
@@ -35,11 +35,11 @@ describe SUSE::Connect::Connection do
 
     context :default_values do
       it 'set ssl to true by default' do
-        secure_connection.http.use_ssl?.should be true
+        expect(secure_connection.http.use_ssl?).to be true
       end
 
       it 'set insecure to false by default' do
-        secure_connection.http.verify_mode.should eq OpenSSL::SSL::VERIFY_PEER
+        expect(secure_connection.http.verify_mode).to eq OpenSSL::SSL::VERIFY_PEER
       end
 
       it 'sets a default verify_callack' do
@@ -73,11 +73,11 @@ describe SUSE::Connect::Connection do
       end
 
       it 'set ssl to true by default' do
-        secure_connection.http.use_ssl?.should be true
+        expect(secure_connection.http.use_ssl?).to be true
       end
 
       it 'set insecure to false by default' do
-        secure_connection.http.verify_mode.should eq OpenSSL::SSL::VERIFY_NONE
+        expect(secure_connection.http.verify_mode).to eq OpenSSL::SSL::VERIFY_NONE
       end
 
       it 'sets the provided verify_callback' do
@@ -149,7 +149,7 @@ describe SUSE::Connect::Connection do
 
       connection = subject.new('https://example.com', :language => 'blabla')
       result = connection.post('/api/v1/test', :auth => 'Token token=zulu')
-      result.code.should eq 200
+      expect(result.code).to eq 200
     end
 
     it 'sends Accept header with api versioning' do
@@ -160,7 +160,7 @@ describe SUSE::Connect::Connection do
 
       connection = subject.new('https://example.com')
       result = connection.post('/api/v1/test', :auth => 'Token token=zulu')
-      result.code.should eq 200
+      expect(result.code).to eq 200
     end
 
     it 'sends USER-AGENT header with SUSEConnect package version' do
@@ -177,7 +177,7 @@ describe SUSE::Connect::Connection do
 
       connection = subject.new('https://example.com')
       result = connection.post('/api/v1/test')
-      result.code.should eq 200
+      expect(result.code).to eq 200
     end
 
     it 'converts response into proper hash' do
@@ -186,8 +186,8 @@ describe SUSE::Connect::Connection do
         .to_return(:status => 200, :body => "{\"keyyo\":\"vallue\"}", :headers => {})
 
       result = connection.post('/api/v1/test', :auth => 'Token token=zulu')
-      result.body.should eq('keyyo' => 'vallue')
-      result.code.should eq 200
+      expect(result.body).to eq('keyyo' => 'vallue')
+      expect(result.code).to eq 200
     end
 
     it 'response includes API response headers' do
@@ -199,8 +199,8 @@ describe SUSE::Connect::Connection do
 
       connection = subject.new('https://example.com')
       result = connection.post('/api/v1/test', :auth => 'Token token=zulu')
-      result.headers['scc-api-version'].first.should eq api_version
-      result.code.should eq 200
+      expect(result.headers['scc-api-version'].first).to eq api_version
+      expect(result.code).to eq 200
     end
 
     it 'send params alongside with request' do
@@ -213,8 +213,8 @@ describe SUSE::Connect::Connection do
         :auth => 'Token token=zulu',
         :params => { :foo => 'bar', :bar => [1, 3, 4] }
       )
-      result.body.should eq('keyyo' => 'vallue')
-      result.code.should eq 200
+      expect(result.body).to eq('keyyo' => 'vallue')
+      expect(result.code).to eq 200
     end
 
     it 'accepts empty request body' do
@@ -260,8 +260,8 @@ describe SUSE::Connect::Connection do
       connection.should_receive(:json_request).and_return parsed_output
       expect { connection.post('/api/v1/test', :auth   => 'Token token=zulu', :params => {}) }
         .to raise_error(ApiError) do |error|
-        error.code.should eq 422
-        error.response.body.should eq('error' => 'These are not the droids you were looking for')
+        expect(error.code).to eq 422
+        expect(error.response.body).to eq('error' => 'These are not the droids you were looking for')
       end
     end
   end

--- a/spec/connect/core_ext/hash_refinement_spec.rb
+++ b/spec/connect/core_ext/hash_refinement_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'suse/connect/core_ext/hash_refinement'
+
+describe SUSE::Connect::CoreExt::HashRefinement do
+  describe '.to_openstruct' do
+    using described_class
+
+    let(:hash) { { a: 1, b: 2 } }
+
+    it 'converts hash to openstruct' do
+      result = hash.to_openstruct
+      expect(result).to be_a OpenStruct
+      expect(result).to respond_to :a
+      expect(result).to respond_to :b
+    end
+  end
+end

--- a/spec/connect/credentials_spec.rb
+++ b/spec/connect/credentials_spec.rb
@@ -94,4 +94,13 @@ describe SUSE::Connect::Credentials do
       expect(credentials_str).to include(file)
     end
   end
+
+  describe '#to_h' do
+    it 'returns a hash representation of the object' do
+      hash = Credentials.new('USER', '*eiW0yie2*', 'FOO_credentials').to_h
+      expect(hash.values).to include('USER')
+      expect(hash.values).to include('*eiW0yie2*')
+      expect(hash.values).to include('FOO_credentials')
+    end
+  end
 end

--- a/spec/connect/migration_spec.rb
+++ b/spec/connect/migration_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe SUSE::Connect::Migration do
   describe '#system_products' do
-    let(:zypper_product) { Zypper::Product.new(:name => 'SLES', :version => '12', :arch => 'x86_64') }
-    let(:remote_product) { Remote::Product.new(:identifier => 'SLES', :version => '12', :arch => 'x86_64', :release_type => 'HP-CNB') }
+    let(:zypper_product) { Zypper::Product.new(name: 'SLES', version: '12', arch: 'x86_64') }
+    let(:remote_product) { Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64', release_type: 'HP-CNB') }
 
     it 'returns installed products and status activated products' do
       expect_any_instance_of(SUSE::Connect::Status).to receive(:system_products).and_return([Product.transform(zypper_product),

--- a/spec/connect/migration_spec.rb
+++ b/spec/connect/migration_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe SUSE::Connect::Migration do
+  describe '#system_products' do
+    let(:zypper_product) { Zypper::Product.new(:name => 'SLES', :version => '12', :arch => 'x86_64') }
+    let(:remote_product) { Remote::Product.new(:identifier => 'SLES', :version => '12', :arch => 'x86_64', :release_type => 'HP-CNB') }
+
+    it 'returns installed products and status activated products' do
+      expect_any_instance_of(SUSE::Connect::Status).to receive(:system_products).and_return([Product.transform(zypper_product),
+                                                                                             Product.transform(remote_product)])
+      result = described_class.system_products
+      expect(result).to match_array([Product.transform(zypper_product), Product.transform(remote_product)])
+    end
+  end
+
+  describe '#add_service' do
+    it 'forwards to zypper add_service' do
+      service_url = 'http://bla.bla'
+      service_name = 'bla'
+      expect(SUSE::Connect::Zypper).to receive(:add_service).with(service_url, service_name)
+
+      described_class.add_service(service_url, service_name)
+    end
+  end
+
+  describe '#remove_service' do
+    it 'forwards to zypper remove_service' do
+      service_name = 'bla'
+      expect(SUSE::Connect::Zypper).to receive(:remove_service).with(service_name)
+
+      described_class.remove_service(service_name)
+    end
+  end
+
+end

--- a/spec/connect/remote/product_spec.rb
+++ b/spec/connect/remote/product_spec.rb
@@ -85,4 +85,10 @@ describe SUSE::Connect::Remote::Product do
       expect(subject.to_params).to eq(identifier: 'SLEEK-12', version: '12', arch: 'x86_64', release_type: 'HP-CNB')
     end
   end
+
+  describe '#to_openstruct' do
+    it 'responds to to_openstruct method' do
+      expect(subject).to respond_to(:to_openstruct)
+    end
+  end
 end

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -89,7 +89,7 @@ describe SUSE::Connect::Status do
         status = Zypper::ProductStatus.new(Zypper::Product.new({}), subject)
         status.stub(:registration_status) { 'test' }
         status.stub(:remote_product) { true }
-        status.stub_chain(:remote_product, :free).and_return(false)
+        expect(status).to receive_message_chain(:remote_product, :free).and_return(false)
         activation = SUSE::Connect::Remote::Activation.new('service' => { 'product' => {} })
         status.stub(:related_activation).and_return(activation)
 
@@ -132,7 +132,7 @@ describe SUSE::Connect::Status do
 
     describe '?products_from_zypper' do
       it 'uses zypper output to collect info' do
-        Zypper.stub_chain(:installed_products).and_return [1, 2, 3]
+        expect(Zypper).to receive_message_chain(:installed_products).and_return [1, 2, 3]
         expect(subject.send(:products_from_zypper)).to eq [1, 2, 3]
       end
     end
@@ -142,7 +142,7 @@ describe SUSE::Connect::Status do
         fake_client = double('client')
         allow(Client).to receive(:new).and_return(fake_client)
         SUSE::Connect::System.stub(:credentials?) { true }
-        fake_client.stub_chain(:system_activations, :body, :map).and_return [1, 2, 3]
+        expect(fake_client).to receive_message_chain(:system_activations, :body, :map).and_return [1, 2, 3]
         expect(subject.send(:products_from_activations)).to eq [1, 2, 3]
       end
     end

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -36,8 +36,9 @@ describe SUSE::Connect::System do
 
       it 'should return username and password' do
         File.stub(:read).with(credentials_file).and_return("username=bill\npassword=nevermore")
-        subject.credentials.username.should eq 'bill'
-        subject.credentials.password.should eq 'nevermore'
+
+        expect(subject.credentials.username).to eq 'bill'
+        expect(subject.credentials.password).to eq 'nevermore'
       end
     end
 
@@ -47,7 +48,7 @@ describe SUSE::Connect::System do
       end
 
       it 'should produce log message' do
-        subject.credentials.should be_nil
+        expect(subject.credentials).to be_nil
       end
     end
 
@@ -58,7 +59,7 @@ describe SUSE::Connect::System do
       end
 
       it 'should remove credentials file' do
-        subject.remove_credentials.should be true
+        expect(subject.remove_credentials).to be true
       end
     end
   end
@@ -66,26 +67,26 @@ describe SUSE::Connect::System do
   describe '.credentials?' do
     it 'returns false if no credentials' do
       subject.stub(credentials: nil)
-      subject.credentials?.should be false
+      expect(subject.credentials?).to be false
     end
 
     it 'returns true if credentials exist' do
       subject.stub(credentials: Credentials.new('123456789', 'ABCDEF'))
-      subject.credentials?.should be true
+      expect(subject.credentials?).to be true
     end
   end
 
   describe '.activated_base_product?' do
     it 'returns false if sytem does not have a credentials' do
       subject.stub(:credentials? => false)
-      subject.activated_base_product?.should be false
+      expect(subject.activated_base_product?).to be false
     end
 
     it 'returns false if sytem has credentials but not activated' do
       subject.stub(credentials?: true)
       Zypper.stub(:base_product)
       expect(SUSE::Connect::Status).to receive(:activated_products).and_return([])
-      subject.activated_base_product?.should be false
+      expect(subject.activated_base_product?).to be false
     end
 
     it 'returns true if sytem has credentials and activated' do
@@ -94,7 +95,7 @@ describe SUSE::Connect::System do
 
       expect(Zypper).to receive(:base_product).and_return(product)
       expect(SUSE::Connect::Status).to receive(:activated_products).and_return([product])
-      subject.activated_base_product?.should be true
+      expect(subject.activated_base_product?).to be true
     end
   end
 
@@ -134,7 +135,7 @@ describe SUSE::Connect::System do
     context :hostname_detected do
       it 'returns hostname' do
         Socket.stub(:gethostname => 'vargan')
-        subject.hostname.should eq 'vargan'
+        expect(subject.hostname).to eq 'vargan'
       end
     end
 
@@ -143,7 +144,7 @@ describe SUSE::Connect::System do
         stubbed_ip_address_list = [Addrinfo.ip('127.0.0.1'), Addrinfo.ip('192.168.42.100'), Addrinfo.ip('192.168.42.42')]
         Socket.stub(:ip_address_list => stubbed_ip_address_list)
         Socket.stub(:gethostname => nil)
-        subject.hostname.should eq '192.168.42.100'
+        expect(subject.hostname).to eq '192.168.42.100'
       end
     end
 
@@ -152,7 +153,7 @@ describe SUSE::Connect::System do
         stubbed_ip_address_list = [Addrinfo.ip('127.0.0.1'), Addrinfo.ip('192.168.42.42')]
         Socket.stub(:ip_address_list => stubbed_ip_address_list)
         Socket.stub(:gethostname => '(none)')
-        subject.hostname.should eq '192.168.42.42'
+        expect(subject.hostname).to eq '192.168.42.42'
       end
     end
 
@@ -161,7 +162,7 @@ describe SUSE::Connect::System do
         stubbed_ip_address_list = [Addrinfo.ip('127.0.0.1'), Addrinfo.ip('44.0.0.69')]
         Socket.stub(:ip_address_list => stubbed_ip_address_list)
         Socket.stub(:gethostname => nil)
-        subject.hostname.should eq nil
+        expect(subject.hostname).to eq nil
       end
     end
   end
@@ -169,7 +170,7 @@ describe SUSE::Connect::System do
   describe '.read_file' do
     it 'reads file' do
       instance_file_path = 'spec/fixtures/instance_data.xml'
-      subject.read_file(instance_file_path).should eq File.read(instance_file_path)
+      expect(subject.read_file(instance_file_path)).to eq File.read(instance_file_path)
     end
 
     it 'raises on unreadable file' do

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -63,60 +63,63 @@ describe SUSE::Connect::YaST do
   describe '#activate_product' do
     let(:client_params) { { token: 'regcode' } }
     let(:product) { Remote::Product.new(identifier: 'win95') }
+    let(:openstruct_product) { product.to_openstruct }
     let(:email) { 'foo@bar.zer' }
 
-    before { Client.any_instance.stub :activate_product }
-
     it 'calls activate_product on an instance of Client' do
-      Client.any_instance.should_receive(:activate_product)
+      expect_any_instance_of(Client).to receive(:activate_product)
       subject.activate_product(nil)
     end
 
     it 'forwards all params to an instance of Client' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
       expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with(client_params).and_call_original
-      Client.any_instance.should_receive(:activate_product)
-      subject.activate_product(*[product, client_params, email])
+      expect_any_instance_of(Client).to receive(:activate_product)
+
+      subject.activate_product(*[openstruct_product, client_params, email])
     end
 
     it 'falls back to use an empty Hash as params if none are specified' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      Client.any_instance.should_receive(:activate_product)
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect_any_instance_of(Client).to receive(:activate_product)
+
       subject.activate_product(nil)
     end
 
     it 'uses product_ident and email as parameter for Client#activate_product' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      Client.any_instance.should_receive(:activate_product).with(product, email)
-      subject.activate_product(*[product, client_params, email])
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect_any_instance_of(Client).to receive(:activate_product).with(openstruct_product, email)
+
+      subject.activate_product(*[openstruct_product, client_params, email])
     end
   end
 
   describe '#upgrade_product' do
     let(:product) { Remote::Product.new(identifier: 'win98') }
+    let(:openstruct_product) { product.to_openstruct }
     let(:client_params) { { :foo => 'oink' } }
 
-    before { Client.any_instance.stub :upgrade_product }
+    before { allow_any_instance_of(Client).to receive(:upgrade_product) }
 
     it 'calls upgrade_product on an instance of Client' do
-      Client.any_instance.should_receive :upgrade_product
-      subject.upgrade_product(product)
+      expect_any_instance_of(Client).to receive :upgrade_product
+      subject.upgrade_product(openstruct_product)
     end
 
     it 'forwards all params to an instance of Client' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
       expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with(client_params).and_call_original
-      subject.upgrade_product product, client_params
+      subject.upgrade_product openstruct_product, client_params
     end
 
     it 'falls back to use an empty Hash as params if none are specified' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      subject.upgrade_product product
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      subject.upgrade_product openstruct_product
     end
 
     it 'forwards product_ident to Client#upgrade_product' do
-      Client.any_instance.should_receive(:upgrade_product).with(product)
-      subject.upgrade_product product
+      expect_any_instance_of(Client).to receive(:upgrade_product).with(openstruct_product)
+      subject.upgrade_product openstruct_product
     end
   end
 
@@ -172,11 +175,12 @@ describe SUSE::Connect::YaST do
 
   describe '#show_product' do
     let(:product) { Remote::Product.new(identifier: 'tango') }
+    let(:openstruct_product) { product.to_openstruct }
     let(:client_params) { { foo: 'oink' } }
 
     it 'calls show_product on an instance of Client' do
-      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
-      subject.show_product product
+      expect_any_instance_of(Client).to receive(:show_product).with(openstruct_product).and_return product
+      expect(subject.show_product(product)).to eq openstruct_product
     end
 
     it 'forwards all params to an instance of Client' do
@@ -184,46 +188,47 @@ describe SUSE::Connect::YaST do
 
       expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with(client_params).and_call_original
       expect(Client).to receive(:new).with(config).and_call_original
-      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+      expect_any_instance_of(Client).to receive(:show_product).with(openstruct_product).and_return product
 
-      subject.show_product product, client_params
+      subject.show_product openstruct_product, client_params
     end
 
     it 'falls back to use an empty Hash as params if none are specified' do
       expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with({}).and_call_original
       expect(Client).to receive(:new).with(SUSE::Connect::Config.new).and_call_original
-      expect_any_instance_of(Client).to receive(:show_product).and_return product
+      expect_any_instance_of(Client).to receive(:show_product).with(openstruct_product).and_return product
 
-      subject.show_product product
+      subject.show_product openstruct_product
     end
 
     it 'uses product as parameter for Client#list_products' do
       expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+      expect_any_instance_of(Client).to receive(:show_product).with(openstruct_product).and_return product
 
-      subject.show_product product
+      subject.show_product openstruct_product
     end
 
     it 'returns product as an instance of OpenStruct' do
       expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+      expect_any_instance_of(Client).to receive(:show_product).with(openstruct_product).and_return product
 
-      expect(subject.show_product(product)).to be_kind_of(OpenStruct)
+      expect(subject.show_product(openstruct_product)).to be_kind_of(OpenStruct)
     end
   end
 
   describe '#product_activated?' do
     let(:product) { Remote::Product.new(identifier: 'tango') }
+    let(:openstruct_product) { product.to_openstruct }
 
     it 'returns false if no credentials' do
       expect(System).to receive(:credentials?).and_return(false)
-      expect(subject.product_activated?(product)).to be false
+      expect(subject.product_activated?(openstruct_product)).to be false
     end
 
     it 'checks if the given product is already activated in SCC' do
       expect(System).to receive(:credentials?).and_return(true)
       expect_any_instance_of(Status).to receive(:activated_products).and_return([product])
-      expect(subject.product_activated?(product)).to be true
+      expect(subject.product_activated?(openstruct_product)).to be true
     end
 
     it 'allows to pass a Hash with params to instantiate the client' do
@@ -232,7 +237,7 @@ describe SUSE::Connect::YaST do
       params_hash = { foo: 'bar' }
       allow(status).to receive(:activated_products).and_return([product])
       expect(subject).to receive(:status).with(params_hash).and_return status
-      expect(subject.product_activated?(product, params_hash)).to be true
+      expect(subject.product_activated?(openstruct_product, params_hash)).to be true
     end
   end
 
@@ -252,31 +257,44 @@ describe SUSE::Connect::YaST do
         Remote::Product.new(:identifier => 'SUSE-Cloud', :version => '7', :arch => 'x86_64', :release_type => nil)
       ]
     end
+
+    let(:openstruct_products) { products.map(&:to_openstruct) }
+    let(:migrations) { [products] }
     let(:client_params) { { :foo => 'oink' } }
 
     it 'calls system_migrations on an instance of Client' do
       expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      expect_any_instance_of(Client).to receive(:system_migrations)
+      expect_any_instance_of(Client).to receive(:system_migrations).and_return migrations
 
-      subject.system_migrations products, client_params
+      subject.system_migrations openstruct_products, client_params
     end
 
     it 'uses products list as parameter for Client#system_migrations' do
       expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      expect_any_instance_of(Client).to receive(:system_migrations).with(products)
+      expect_any_instance_of(Client).to receive(:system_migrations).with(openstruct_products).and_return migrations
 
-      subject.system_migrations products, client_params
+      subject.system_migrations openstruct_products, client_params
     end
 
     it 'returns the output received from Client' do
       expected_migration = [[Remote::Product.new(identifier: 'SLES')]]
 
       expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      expect_any_instance_of(Client).to receive(:system_migrations).with(products).and_return(expected_migration)
+      expect_any_instance_of(Client).to receive(:system_migrations).with(openstruct_products).and_return(expected_migration)
 
-      actual_migration = subject.system_migrations products, client_params
+      actual_migration = subject.system_migrations(openstruct_products, client_params)
 
       expect(actual_migration).to eq(expected_migration)
+    end
+
+    it 'returns an array of arrays with openstruct objects' do
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect_any_instance_of(Client).to receive(:system_migrations).with(products).and_return(migrations)
+      migrations = subject.system_migrations products, client_params
+
+      expect(migrations).to be_kind_of Array
+      expect(migrations.first).to be_kind_of Array
+      expect(migrations.first.first).to be_kind_of OpenStruct
     end
   end
 

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -174,6 +174,15 @@ describe SUSE::Connect::YaST do
     end
   end
 
+  describe '#activated_products' do
+    let(:remote_product) { Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64', release_type: 'HP-CNB') }
+
+    it 'returns an array of activated system products' do
+      expect_any_instance_of(SUSE::Connect::Status).to receive(:activated_products).and_return([remote_product])
+      expect(SUSE::Connect::YaST.activated_products).to match_array([remote_product.to_openstruct])
+    end
+  end
+
   describe '#system_migrations' do
     let(:products) do
       [

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -120,6 +120,31 @@ describe SUSE::Connect::YaST do
     end
   end
 
+  describe '.credentials' do
+    let(:login) { 'login' }
+    let(:password) { 'password' }
+    let(:system_credentials) { Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE) }
+
+    context 'with no arguments' do
+      it 'reads system credentials file' do
+        expect(Credentials).to receive(:read).with(subject::GLOBAL_CREDENTIALS_FILE).and_return(system_credentials)
+        subject.credentials
+      end
+    end
+
+    context 'with credentials_file argument' do
+      it 'reads credentials from given path' do
+        expect(Credentials).to receive(:read).with('/tmp/credentials').and_return(system_credentials)
+        subject.credentials('/tmp/credentials')
+      end
+    end
+
+    it 'returns an OpenStruct instance' do
+      expect(Credentials).to receive(:read).with(subject::GLOBAL_CREDENTIALS_FILE).and_return(system_credentials)
+      expect(subject.credentials).to be_kind_of(OpenStruct)
+    end
+  end
+
   describe '.create_credentials_file' do
     let(:login) { 'login' }
     let(:password) { 'password' }

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -280,37 +280,6 @@ describe SUSE::Connect::YaST do
     end
   end
 
-  describe '#system_products' do
-    let(:zypper_product) { Zypper::Product.new(:name => 'SLES', :version => '12', :arch => 'x86_64') }
-    let(:remote_product) { Remote::Product.new(:identifier => 'SLES', :version => '12', :arch => 'x86_64', :release_type => 'HP-CNB') }
-
-    it 'returns installed products and status activated products' do
-      expect_any_instance_of(SUSE::Connect::Status).to receive(:system_products).and_return([Product.transform(zypper_product),
-                                                                                             Product.transform(remote_product)])
-      result = SUSE::Connect::YaST.system_products
-      expect(result).to match_array([Product.transform(zypper_product), Product.transform(remote_product)])
-    end
-  end
-
-  describe '#add_service' do
-    it 'forwards to zypper add_service' do
-      service_url = 'http://bla.bla'
-      service_name = 'bla'
-      expect(SUSE::Connect::Zypper).to receive(:add_service).with(service_url, service_name)
-
-      SUSE::Connect::YaST.add_service(service_url, service_name)
-    end
-  end
-
-  describe '#remove_service' do
-    it 'forwards to zypper remove_service' do
-      service_name = 'bla'
-      expect(SUSE::Connect::Zypper).to receive(:remove_service).with(service_name)
-
-      SUSE::Connect::YaST.remove_service(service_name)
-    end
-  end
-
   describe '#write_config' do
     let(:params) { { url: 'http://scc.foo.com' } }
 

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -147,31 +147,43 @@ describe SUSE::Connect::YaST do
 
   describe '#show_product' do
     let(:product) { Remote::Product.new(identifier: 'tango') }
-    let(:client_params) { { :foo => 'oink' } }
+    let(:client_params) { { foo: 'oink' } }
 
-    before { Client.any_instance.stub :show_product }
-
-    it 'calls list_products on an instance of Client' do
-      Client.any_instance.should_receive(:show_product)
+    it 'calls show_product on an instance of Client' do
+      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
       subject.show_product product
     end
 
     it 'forwards all params to an instance of Client' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      Client.any_instance.should_receive(:show_product)
+      config = SUSE::Connect::Config.new.merge!(client_params)
+
+      expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with(client_params).and_call_original
+      expect(Client).to receive(:new).with(config).and_call_original
+      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+
       subject.show_product product, client_params
     end
 
     it 'falls back to use an empty Hash as params if none are specified' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      Client.any_instance.should_receive(:show_product)
+      expect_any_instance_of(SUSE::Connect::Config).to receive(:merge!).with({}).and_call_original
+      expect(Client).to receive(:new).with(SUSE::Connect::Config.new).and_call_original
+      expect_any_instance_of(Client).to receive(:show_product).and_return product
+
       subject.show_product product
     end
 
     it 'uses product as parameter for Client#list_products' do
-      Client.should_receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
-      Client.any_instance.should_receive(:show_product).with(product)
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+
       subject.show_product product
+    end
+
+    it 'returns product as an instance of OpenStruct' do
+      expect(Client).to receive(:new).with(instance_of(SUSE::Connect::Config)).and_call_original
+      expect_any_instance_of(Client).to receive(:show_product).with(product).and_return product
+
+      expect(subject.show_product(product)).to be_kind_of(OpenStruct)
     end
   end
 

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -120,6 +120,31 @@ describe SUSE::Connect::YaST do
     end
   end
 
+  describe '.create_credentials_file' do
+    let(:login) { 'login' }
+    let(:password) { 'password' }
+    let(:credentials) { Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE) }
+
+    it 'creates credentials file with default parameter' do
+      credentials = Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE)
+
+      expect(Credentials).to receive(:new).with(login, password, subject::GLOBAL_CREDENTIALS_FILE).and_return credentials
+      expect(credentials).to receive(:write)
+
+      subject.create_credentials_file(login, password)
+    end
+
+    it 'creates credentials file with passed parameter' do
+      credentials_file = '/tmp/Credentials'
+      credentials = Credentials.new(login, password, credentials_file)
+
+      expect(Credentials).to receive(:new).with(login, password, credentials_file).and_return credentials
+      expect(credentials).to receive(:write)
+
+      subject.create_credentials_file(login, password, credentials_file)
+    end
+  end
+
   describe '#show_product' do
     let(:product) { Remote::Product.new(identifier: 'tango') }
     let(:client_params) { { :foo => 'oink' } }

--- a/spec/connect/zypper/product_status_spec.rb
+++ b/spec/connect/zypper/product_status_spec.rb
@@ -55,7 +55,7 @@ describe SUSE::Connect::Zypper::ProductStatus do
     it 'finds related activation by comparing installing and remote product' do
       activation = double('activation')
       remote_product = Remote::Product.new(:identifier => :foo, :version => 42, :arch => :wax)
-      activation.stub_chain(:service, :product).and_return remote_product
+      expect(activation).to receive_message_chain(:service, :product).and_return remote_product
       allow(status).to receive(:activations).and_return [activation]
       allow(subject).to receive(:remote_product).and_return remote_product
       expect(subject.related_activation).to eq activation

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -24,19 +24,19 @@ describe SUSE::Connect::Zypper do
         end
 
         it 'returns valid list of products based on proper XML' do
-          subject.installed_products.first.identifier.should eq 'SUSE_SLES'
+          expect(subject.installed_products.first.identifier).to eq 'SUSE_SLES'
         end
 
         it 'returns valid version' do
-          subject.installed_products.first.version.should eq '11.3'
+          expect(subject.installed_products.first.version).to eq '11.3'
         end
 
         it 'returns valid arch' do
-          subject.installed_products.first.arch.should eq 'x86_64'
+          expect(subject.installed_products.first.arch).to eq 'x86_64'
         end
 
         it 'returns proper base product' do
-          subject.base_product.identifier.should eq 'SUSE_SLES'
+          expect(subject.base_product.identifier).to eq 'SUSE_SLES'
         end
       end
     end
@@ -51,19 +51,19 @@ describe SUSE::Connect::Zypper do
         end
 
         it 'returns valid name' do
-          subject.installed_products.first.identifier.should eq 'SLES'
+          expect(subject.installed_products.first.identifier).to eq 'SLES'
         end
 
         it 'returns valid version' do
-          subject.installed_products.first.version.should eq '12'
+          expect(subject.installed_products.first.version).to eq '12'
         end
 
         it 'returns valid arch' do
-          subject.installed_products.first.arch.should eq 'x86_64'
+          expect(subject.installed_products.first.arch).to eq 'x86_64'
         end
 
         it 'returns proper base product' do
-          subject.base_product.identifier.should eq 'SLES'
+          expect(subject.base_product.identifier).to eq 'SLES'
         end
       end
     end
@@ -236,7 +236,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'should return first product from installed product which is base' do
-      subject.base_product.should eq(parsed_products.first)
+      expect(subject.base_product).to eq(parsed_products.first)
     end
 
     it 'raises CannotDetectBaseProduct if cant get base system from list of installed products' do
@@ -280,7 +280,7 @@ describe SUSE::Connect::Zypper do
   describe '.distro_target' do
     it 'return zypper targetos output' do
       Open3.should_receive(:capture3).with(shared_env_hash, 'zypper targetos').and_return(['openSUSE-13.1-x86_64', '', status])
-      Zypper.distro_target.should eq 'openSUSE-13.1-x86_64'
+      expect(Zypper.distro_target).to eq 'openSUSE-13.1-x86_64'
     end
 
     it 'return zypper targetos output --root case' do
@@ -288,7 +288,7 @@ describe SUSE::Connect::Zypper do
       Open3.should_receive(:capture3).with(shared_env_hash, args).and_return(['openSUSE-13.1-x86_64', '', status])
 
       SUSE::Connect::System.filesystem_root = '/path/to/root'
-      Zypper.distro_target.should eq 'openSUSE-13.1-x86_64'
+      expect(Zypper.distro_target).to eq 'openSUSE-13.1-x86_64'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ SimpleCov.start do
 end
 
 require 'rspec'
-require 'ap'
 require 'byebug'
+require 'awesome_print'
 require 'webmock/rspec'
 require 'suse/connect'
 

--- a/spec/toolkit/cast_spec.rb
+++ b/spec/toolkit/cast_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+# Into this class instance we include subject module
+class DummyReceiver < OpenStruct
+  include SUSE::Toolkit::Cast
+end
+
+describe SUSE::Toolkit::Cast do
+  subject { DummyReceiver.new({ a: 1, b: 2, c: [DummyReceiver.new(x: 7, y: 8)] }) }
+
+  describe '.to_openstruct' do
+    it 'casts an object to openstruct' do
+      expect(subject.to_openstruct).to be_a OpenStruct
+    end
+
+    it 'performs a deep cast on the object with a class instances in array values' do
+      expect(subject.to_openstruct.c.first).to be_a OpenStruct
+    end
+  end
+
+  describe '.attributes' do
+    it 'returns the attributes as a hash' do
+      expect(subject.attributes).to be_a Hash
+    end
+
+    it 'converts the nested attribute values to hash' do
+      expect(subject.attributes[:c].first).to be_a Hash
+    end
+  end
+end

--- a/spec/toolkit/cast_spec.rb
+++ b/spec/toolkit/cast_spec.rb
@@ -6,7 +6,7 @@ class DummyReceiver < OpenStruct
 end
 
 describe SUSE::Toolkit::Cast do
-  subject { DummyReceiver.new({ a: 1, b: 2, c: [DummyReceiver.new(x: 7, y: 8)] }) }
+  subject { DummyReceiver.new(a: 1, b: 2, c: [DummyReceiver.new(x: 7, y: 8)]) }
 
   describe '.to_openstruct' do
     it 'casts an object to openstruct' do

--- a/spec/toolkit/system_calls_spec.rb
+++ b/spec/toolkit/system_calls_spec.rb
@@ -17,8 +17,8 @@ describe SUSE::Toolkit::SystemCalls do
 
   describe '.execute' do
     it 'should make a quiet system call' do
-      subject.should_receive(:capture3).with(shared_env_hash, 'date').and_return([date, '', success])
-      execute('date').should be nil
+      expect(subject).to receive(:capture3).with(shared_env_hash, 'date').and_return([date, '', success])
+      expect(execute('date')).to be nil
     end
 
     it 'should produce debug log output' do

--- a/spec/toolkit/utilities_spec.rb
+++ b/spec/toolkit/utilities_spec.rb
@@ -10,7 +10,7 @@ describe SUSE::Toolkit::Utilities do
 
   describe '?token_auth' do
     it 'returns string for auth header' do
-      subject.send(:token_auth, 'lambada').should eq 'Token token=lambada'
+      expect(subject.send(:token_auth, 'lambada')).to eq 'Token token=lambada'
     end
 
     it 'not raising if no token passed, but method requested' do
@@ -22,7 +22,7 @@ describe SUSE::Toolkit::Utilities do
     it 'returns string for auth header' do
       Credentials.stub(:read => Credentials.new('bob', 'dylan'))
       base64_line = 'Basic Ym9iOmR5bGFu'
-      subject.send(:system_auth).should eq base64_line
+      expect(subject.send(:system_auth)).to eq base64_line
     end
 
     it 'raise if cannot get credentials' do


### PR DESCRIPTION
Please review the following changes:
  * 55f1d15 remove zypper tests from yast_spec
  * 0c224e0 require migration script in connect.rb
  * 95a0985 remove methods wich requires zypper interaction from SUSE::Connect::YaST class
  * 23c1da2 introduce SUSE::Connect::Migration class abd move methods with zypper interactions to it
  * 6aad605 Merge branch 'master' into review_150714_add_activated_products_method_and_return_plain_openstruct_objects
  * e161bd3 add .credentials method to yast.rb layer which read a credentials file and returns the results
  * 09a0ab7 add to_h method which returns a hash representaion of the object
  * 7a2aa58 re-factor and add test to yast.rb
  * a31cdb1 return remote product as an instance of OpenStruct
  * ee1dc59 fix rubocop offences
  * 316c780 add create_credentials_file to yast.rb
  * ae7d857 ensure RemoteProduct responds to to_openstruct method
  * 69e9d7c ruby refinements instead of monkey-patch
  * 4a4bcae fix rubocop offences
  * a0fbb06 fix rubocop offences
  * 63b1c6b add activated_products to yast.rb layer
  * ae7efaa extend SUSE::Connect::Remote::Product with a methods from ::Cast module
  * 0337249 add SUSE::Connect::Toolkit::Cast module
  * 32cc3ec require awesome_print in test env