### PR TITLE
[Review] Request from 'vlewin' @ 'SUSE/connect/review_150724_repositories_handling'

### DIFF
--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -33,7 +33,7 @@ module SUSE
         # @return [Array <OpenStruct>] the list of zypper repositories
         def repositories
           # INFO: use block instead of .map(&:to_openstruct) see https://bugs.ruby-lang.org/issues/9786
-          Zypper.repositories.map{|r| r.to_openstruct }
+          Zypper.repositories.map {|r| r.to_openstruct }
         end
 
         # Forwards the service which should be added with zypper

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -1,9 +1,13 @@
+require 'suse/connect/core_ext/hash_refinement'
+
 module SUSE
   module Connect
 
     # Migration class is an abstraction layer for SLE migration script
     # Migration script call this class from: https://github.com/nadvornik/zypper-migration/blob/master/zypper-migration
     class Migration
+      using SUSE::Connect::CoreExt::HashRefinement
+
       class << self
         # Returns installed and activated products on the system
         # @param [Hash] client_params parameters to instantiate {Client}
@@ -11,6 +15,25 @@ module SUSE
         def system_products(client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
           Status.new(config).system_products.map(&:to_openstruct)
+        end
+
+        # Forwards the repository which should be enabled with zypper
+        # @param [String] repository name to enable
+        def enable_repository(name)
+          Zypper.enable_repository(name)
+        end
+
+        # Forwards the repository which should be disabled with zypper
+        # @param [String] repository name to disable
+        def disable_repository(name)
+          Zypper.disable_repository(name)
+        end
+
+        # Returns the list of available repositories
+        # @return [Array <OpenStruct>] the list of zypper repositories
+        def repositories
+          # INFO: use block instead of .map(&:to_openstruct) see https://bugs.ruby-lang.org/issues/9786
+          Zypper.repositories.map{|r| r.to_openstruct }
         end
 
         # Forwards the service which should be added with zypper

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -45,7 +45,7 @@ module SUSE
         def repositories
           zypper_out = call('--xmlout --non-interactive repos -d', false)
           xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
-          xml_doc.elements.each('stream/repo-list/repo'){}.map{|r| r.to_hash.merge!(url: r.elements['url'].text) }
+          xml_doc.elements.each('stream/repo-list/repo') {}.map {|r| r.to_hash.merge!(url: r.elements['url'].text) }
         end
 
         # @param service_url [String] url to appropriate repomd.xml to be fed to zypper

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -33,6 +33,21 @@ module SUSE
           call('targetos', false)
         end
 
+        def enable_repository(name)
+          call("--non-interactive modifyrepo -e #{name}")
+        end
+
+        def disable_repository(name)
+          call("--non-interactive modifyrepo -d #{name}")
+        end
+
+        # Returns an array of hashes of all available repositories
+        def repositories
+          zypper_out = call('--xmlout --non-interactive repos -d', false)
+          xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
+          xml_doc.elements.each('stream/repo-list/repo'){}.map{|r| r.to_hash.merge!(url: r.elements['url'].text) }
+        end
+
         # @param service_url [String] url to appropriate repomd.xml to be fed to zypper
         # @param service_name [String] Alias-mnemonic with which zypper should add this service
         # @return [TrueClass]

--- a/spec/connect/credentials_spec.rb
+++ b/spec/connect/credentials_spec.rb
@@ -32,18 +32,17 @@ describe SUSE::Connect::Credentials do
 
     it 'raises an error when username cannot be parsed' do
       expect(File).to receive(:exist?).and_return(true)
-      expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
-      expect { Credentials.read(credentials_file) }.to raise_error(
-        MalformedSccCredentialsFile,
-        'Cannot parse credentials file')
+      allow(File).to receive(:read).with(credentials_file).and_return("me\nfe")
+      expect { Credentials.read(credentials_file) }.to raise_error(MalformedSccCredentialsFile, 'Cannot parse credentials file')
     end
 
     it 'raises an error when the password cannot be parsed' do
+      allow_any_instance_of(String).to receive(:match).with(/^\s*username\s*=\s*(\S+)\s*$/).and_return(true)
+      allow_any_instance_of(String).to receive(:match).with(/^\s*password\s*=\s*(\S+)\s*$/).and_return(false)
+
       expect(File).to receive(:exist?).and_return(true)
       expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
-      expect { Credentials.read(credentials_file) }.to raise_error(
-        MalformedSccCredentialsFile,
-        'Cannot parse credentials file')
+      expect { Credentials.read(credentials_file) }.to raise_error(MalformedSccCredentialsFile, 'Cannot parse credentials file')
     end
   end
 

--- a/spec/connect/credentials_spec.rb
+++ b/spec/connect/credentials_spec.rb
@@ -31,16 +31,16 @@ describe SUSE::Connect::Credentials do
     end
 
     it 'raises an error when username cannot be parsed' do
-      File.stub(:exist?).and_return(true)
-      File.stub(:read).with(credentials_file).and_return("me\nfe")
+      expect(File).to receive(:exist?).and_return(true)
+      expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
       expect { Credentials.read(credentials_file) }.to raise_error(
         MalformedSccCredentialsFile,
         'Cannot parse credentials file')
     end
 
     it 'raises an error when the password cannot be parsed' do
-      File.stub(:exist?).with(credentials_file).and_return(true)
-      File.stub(:read).with(credentials_file).and_return("username=me\nfe")
+      expect(File).to receive(:exist?).and_return(true)
+      expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
       expect { Credentials.read(credentials_file) }.to raise_error(
         MalformedSccCredentialsFile,
         'Cannot parse credentials file')

--- a/spec/connect/migration_spec.rb
+++ b/spec/connect/migration_spec.rb
@@ -13,25 +13,6 @@ describe SUSE::Connect::Migration do
     end
   end
 
-  # Forwards the repository which should be enabled with zypper
-  # @param [String] repository name to enable
-  def enable_repository(name)
-    Zypper.enable_repository(name)
-  end
-
-  # Forwards the repository which should be disabled with zypper
-  # @param [String] repository name to disable
-  def disable_repository(name)
-    Zypper.disable_repository(name)
-  end
-
-  # Returns the list of available repositories
-  # @return [Array <OpenStruct>] the list of zypper repositories
-  def repositories
-    # INFO: use block instead of .map(&:to_openstruct) see https://bugs.ruby-lang.org/issues/9786
-    Zypper.repositories.map {|r| r.to_openstruct }
-  end
-
   describe '.enable_repository' do
     it 'enables zypper repository' do
       expect(SUSE::Connect::Zypper).to receive(:enable_repository).with('repository_name')
@@ -55,6 +36,16 @@ describe SUSE::Connect::Migration do
     it 'returns an array of OpenStruct objects' do
       expect(SUSE::Connect::Zypper).to receive(:repositories).and_return([{ name: 'foo' }, { name: 'bar' }])
       expect(described_class.repositories.any? {|r| r.is_a?(OpenStruct) }).to be true
+    end
+  end
+
+  describe '.add_service' do
+    it 'forwards to zypper add_service' do
+      service_url = 'http://bla.bla'
+      service_name = 'bla'
+      expect(SUSE::Connect::Zypper).to receive(:add_service).with(service_url, service_name)
+
+      described_class.add_service(service_url, service_name)
     end
   end
 

--- a/spec/connect/migration_spec.rb
+++ b/spec/connect/migration_spec.rb
@@ -29,7 +29,7 @@ describe SUSE::Connect::Migration do
   # @return [Array <OpenStruct>] the list of zypper repositories
   def repositories
     # INFO: use block instead of .map(&:to_openstruct) see https://bugs.ruby-lang.org/issues/9786
-    Zypper.repositories.map{|r| r.to_openstruct }
+    Zypper.repositories.map {|r| r.to_openstruct }
   end
 
   describe '.enable_repository' do
@@ -53,8 +53,8 @@ describe SUSE::Connect::Migration do
     end
 
     it 'returns an array of OpenStruct objects' do
-      expect(SUSE::Connect::Zypper).to receive(:repositories).and_return([{name: 'foo'}, {name: 'bar'}])
-      expect(described_class.repositories.any?{|r| r.is_a?(OpenStruct)}).to be true
+      expect(SUSE::Connect::Zypper).to receive(:repositories).and_return([{ name: 'foo' }, { name: 'bar' }])
+      expect(described_class.repositories.any? {|r| r.is_a?(OpenStruct) }).to be true
     end
   end
 

--- a/spec/connect/migration_spec.rb
+++ b/spec/connect/migration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SUSE::Connect::Migration do
-  describe '#system_products' do
+  describe '.system_products' do
     let(:zypper_product) { Zypper::Product.new(name: 'SLES', version: '12', arch: 'x86_64') }
     let(:remote_product) { Remote::Product.new(identifier: 'SLES', version: '12', arch: 'x86_64', release_type: 'HP-CNB') }
 
@@ -13,17 +13,52 @@ describe SUSE::Connect::Migration do
     end
   end
 
-  describe '#add_service' do
-    it 'forwards to zypper add_service' do
-      service_url = 'http://bla.bla'
-      service_name = 'bla'
-      expect(SUSE::Connect::Zypper).to receive(:add_service).with(service_url, service_name)
+  # Forwards the repository which should be enabled with zypper
+  # @param [String] repository name to enable
+  def enable_repository(name)
+    Zypper.enable_repository(name)
+  end
 
-      described_class.add_service(service_url, service_name)
+  # Forwards the repository which should be disabled with zypper
+  # @param [String] repository name to disable
+  def disable_repository(name)
+    Zypper.disable_repository(name)
+  end
+
+  # Returns the list of available repositories
+  # @return [Array <OpenStruct>] the list of zypper repositories
+  def repositories
+    # INFO: use block instead of .map(&:to_openstruct) see https://bugs.ruby-lang.org/issues/9786
+    Zypper.repositories.map{|r| r.to_openstruct }
+  end
+
+  describe '.enable_repository' do
+    it 'enables zypper repository' do
+      expect(SUSE::Connect::Zypper).to receive(:enable_repository).with('repository_name')
+      described_class.enable_repository('repository_name')
     end
   end
 
-  describe '#remove_service' do
+  describe '.disable_repository' do
+    it 'disables zypper repository' do
+      expect(SUSE::Connect::Zypper).to receive(:disable_repository).with('repository_name')
+      described_class.disable_repository('repository_name')
+    end
+  end
+
+  describe '.repositories' do
+    it 'calls underlying method of Zypper class' do
+      expect(SUSE::Connect::Zypper).to receive(:repositories).and_return([])
+      described_class.repositories
+    end
+
+    it 'returns an array of OpenStruct objects' do
+      expect(SUSE::Connect::Zypper).to receive(:repositories).and_return([{name: 'foo'}, {name: 'bar'}])
+      expect(described_class.repositories.any?{|r| r.is_a?(OpenStruct)}).to be true
+    end
+  end
+
+  describe '.remove_service' do
     it 'forwards to zypper remove_service' do
       service_name = 'bla'
       expect(SUSE::Connect::Zypper).to receive(:remove_service).with(service_name)

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -2,11 +2,8 @@ require 'spec_helper'
 
 describe SUSE::Connect::Zypper do
   before(:each) do
-    Object.stub(system: true)
-  end
-
-  after(:each) do
-    SUSE::Connect::System.filesystem_root = nil
+    allow(SUSE::Connect::System).to receive(:filesystem_root).and_return nil
+    allow(Object).to receive(:system).and_return true
   end
 
   subject { SUSE::Connect::Zypper }
@@ -142,7 +139,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'calls zypper with proper arguments --root case' do
-      SUSE::Connect::System.filesystem_root = '/path/to/root'
+      allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
 
       args = "zypper --root '/path/to/root' --non-interactive addservice -t ris http://example.com 'branding'"
       autorefresh_args = "zypper --root '/path/to/root' --non-interactive modifyservice -r http://example.com"
@@ -163,7 +160,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'calls zypper with proper arguments --root case' do
-      SUSE::Connect::System.filesystem_root = '/path/to/root'
+      allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
 
       args = "zypper --root '/path/to/root' --non-interactive removeservice 'branding'"
       expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['', '', status])
@@ -244,7 +241,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'calls zypper with proper arguments --root case' do
-      SUSE::Connect::System.filesystem_root = '/path/to/root'
+      allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
 
       expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --root '/path/to/root' --non-interactive refresh")
         .and_return(['', '', status])
@@ -259,7 +256,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'calls zypper with proper arguments' do
-      SUSE::Connect::System.filesystem_root = '/path/to/root'
+      allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
 
       expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --root '/path/to/root' --non-interactive refresh-services -r")
         .and_return(['', '', status])
@@ -295,7 +292,7 @@ describe SUSE::Connect::Zypper do
     mock_dry_file
 
     before do
-      Credentials.any_instance.stub(:write)
+      allow_any_instance_of(Credentials).to receive(:write).and_return true
     end
 
     it 'should call write_base_credentials_file' do
@@ -329,10 +326,10 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'return zypper targetos output --root case' do
+      allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
+
       args = "zypper --root '/path/to/root' targetos"
       Open3.should_receive(:capture3).with(shared_env_hash, args).and_return(['openSUSE-13.1-x86_64', '', status])
-
-      SUSE::Connect::System.filesystem_root = '/path/to/root'
       expect(Zypper.distro_target).to eq 'openSUSE-13.1-x86_64'
     end
   end

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -69,7 +69,7 @@ describe SUSE::Connect::Zypper do
     end
   end
 
-  describe '#enable_repository' do
+  describe '.enable_repository' do
     let(:repository) { 'repository' }
 
     it 'enables zypper repository' do
@@ -84,7 +84,7 @@ describe SUSE::Connect::Zypper do
     end
   end
 
-  describe '#disable_repository' do
+  describe '.disable_repository' do
     let(:repository) { 'repository' }
 
     it 'enables zypper repository' do
@@ -96,6 +96,21 @@ describe SUSE::Connect::Zypper do
       exception = "SUSE::Connect::ZypperError: Repository #{repository} not found."
       expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -d #{repository}").and_raise(exception)
       expect{subject.disable_repository(repository)}.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
+    end
+  end
+
+  describe '.repositories' do
+    let(:zypper_output) { File.read('spec/fixtures/zypper_repositories.xml') }
+    let(:args) { 'zypper --xmlout --non-interactive repos -d' }
+
+    before do
+      expect(Open3).to receive(:capture3).with(shared_env_hash, args).at_least(1).and_return([zypper_output, '', status])
+    end
+
+    it 'lists all defined repositories' do
+      expect(subject.repositories.size).to eq 4
+      expect(subject.repositories.first.keys).to match_array([:alias, :name, :type, :priority, :enabled, :autorefresh, :gpgcheck, :url])
+      expect(subject.repositories.map {|service| service[:name] }).to match_array(['SLES12-Debuginfo-Pool', 'SLES12-Debuginfo-Updates', 'SLES12-Pool', 'SLES12-Updates'])
     end
   end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -305,23 +305,23 @@ describe SUSE::Connect::Zypper do
     mock_dry_file
 
     before do
-      Credentials.any_instance.stub(:write)
+      allow_any_instance_of(Credentials).to receive(:write).and_return true
     end
 
     it 'extracts username and password from system credentials' do
-      System.should_receive(:credentials)
+      expect(System).to receive(:credentials)
       subject.write_service_credentials('turbo')
     end
 
     it 'creates a file with source name' do
-      Credentials.should_receive(:new).with('dummy', 'tummy', 'turbo').and_call_original
+      expect(Credentials).to receive(:new).with('dummy', 'tummy', 'turbo').and_call_original
       subject.write_service_credentials('turbo')
     end
   end
 
   describe '.distro_target' do
     it 'return zypper targetos output' do
-      Open3.should_receive(:capture3).with(shared_env_hash, 'zypper targetos').and_return(['openSUSE-13.1-x86_64', '', status])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper targetos').and_return(['openSUSE-13.1-x86_64', '', status])
       expect(Zypper.distro_target).to eq 'openSUSE-13.1-x86_64'
     end
 
@@ -329,7 +329,7 @@ describe SUSE::Connect::Zypper do
       allow(SUSE::Connect::System).to receive(:filesystem_root).and_return '/path/to/root'
 
       args = "zypper --root '/path/to/root' targetos"
-      Open3.should_receive(:capture3).with(shared_env_hash, args).and_return(['openSUSE-13.1-x86_64', '', status])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return(['openSUSE-13.1-x86_64', '', status])
       expect(Zypper.distro_target).to eq 'openSUSE-13.1-x86_64'
     end
   end

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -69,6 +69,36 @@ describe SUSE::Connect::Zypper do
     end
   end
 
+  describe '#enable_repository' do
+    let(:repository) { 'repository' }
+
+    it 'enables zypper repository' do
+      expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -e #{repository}").and_return(['', '', status])
+      subject.enable_repository(repository)
+    end
+
+    it 'raise an exception if repository not found' do
+      exception = "SUSE::Connect::ZypperError: Repository #{repository} not found."
+      expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -e #{repository}").and_raise(exception)
+      expect{subject.enable_repository(repository)}.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
+    end
+  end
+
+  describe '#disable_repository' do
+    let(:repository) { 'repository' }
+
+    it 'enables zypper repository' do
+      expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -d #{repository}").and_return(['', '', status])
+      subject.disable_repository(repository)
+    end
+
+    it 'raise an exception if repository not found' do
+      exception = "SUSE::Connect::ZypperError: Repository #{repository} not found."
+      expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -d #{repository}").and_raise(exception)
+      expect{subject.disable_repository(repository)}.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
+    end
+  end
+
   describe '.add_service' do
     describe 'calls zypper with proper arguments' do
       it 'adds service' do

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -77,7 +77,7 @@ describe SUSE::Connect::Zypper do
     it 'raise an exception if repository not found' do
       exception = "SUSE::Connect::ZypperError: Repository #{repository} not found."
       expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -e #{repository}").and_raise(exception)
-      expect{subject.enable_repository(repository)}.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
+      expect { subject.enable_repository(repository) }.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
     end
   end
 
@@ -92,7 +92,7 @@ describe SUSE::Connect::Zypper do
     it 'raise an exception if repository not found' do
       exception = "SUSE::Connect::ZypperError: Repository #{repository} not found."
       expect(Open3).to receive(:capture3).with(shared_env_hash, "zypper --non-interactive modifyrepo -d #{repository}").and_raise(exception)
-      expect{subject.disable_repository(repository)}.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
+      expect { subject.disable_repository(repository) }.to raise_error("SUSE::Connect::ZypperError: Repository #{repository} not found.")
     end
   end
 
@@ -107,7 +107,7 @@ describe SUSE::Connect::Zypper do
     it 'lists all defined repositories' do
       expect(subject.repositories.size).to eq 4
       expect(subject.repositories.first.keys).to match_array([:alias, :name, :type, :priority, :enabled, :autorefresh, :gpgcheck, :url])
-      expect(subject.repositories.map {|service| service[:name] }).to match_array(['SLES12-Debuginfo-Pool', 'SLES12-Debuginfo-Updates', 'SLES12-Pool', 'SLES12-Updates'])
+      expect(subject.repositories.map {|service| service[:name] }).to match_array(%w{SLES12-Debuginfo-Pool SLES12-Debuginfo-Updates SLES12-Pool SLES12-Updates})
     end
   end
 

--- a/spec/fixtures/zypper_repositories.xml
+++ b/spec/fixtures/zypper_repositories.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0'?>
+  <stream>
+    <repo-list>
+      <repo alias="SUSE_Linux_Enterprise_Server_12_x86_64:SLES12-Debuginfo-Pool" name="SLES12-Debuginfo-Pool" type="rpm-md" priority="99" enabled="0" autorefresh="0" gpgcheck="1">
+        <url>https://updates.suse.com/SUSE/Products/SLE-SERVER/12/x86_64/product_debug</url>
+      </repo>
+      <repo alias="SUSE_Linux_Enterprise_Server_12_x86_64:SLES12-Debuginfo-Updates" name="SLES12-Debuginfo-Updates" type="rpm-md" priority="99" enabled="0" autorefresh="1" gpgcheck="1">
+        <url>https://updates.suse.com/SUSE/Updates/SLE-SERVER/12/x86_64/update_debug</url>
+      </repo>
+      <repo alias="SUSE_Linux_Enterprise_Server_12_x86_64:SLES12-Pool" name="SLES12-Pool" type="rpm-md" priority="99" enabled="1" autorefresh="0" gpgcheck="1">
+        <url>https://updates.suse.com/SUSE/Products/SLE-SERVER/12/x86_64/product</url>
+      </repo>
+      <repo alias="SUSE_Linux_Enterprise_Server_12_x86_64:SLES12-Updates" name="SLES12-Updates" type="rpm-md" priority="99" enabled="1" autorefresh="1" gpgcheck="1">
+        <url>https://updates.suse.com/SUSE/Updates/SLE-SERVER/12/x86_64/update?</url>
+      </repo>
+    </repo-list>
+</stream>

--- a/spec/support/credentials_mocks.rb
+++ b/spec/support/credentials_mocks.rb
@@ -1,8 +1,8 @@
 def mock_dry_file
   let :source_cred_file do
     opened_file = double('me_file')
-    opened_file.stub(:puts => true)
-    opened_file.stub(:close => true)
+    allow(opened_file).to receive(:puts).and_return true
+    allow(opened_file).to receive(:close).and_return true
     opened_file
   end
 
@@ -12,10 +12,10 @@ def mock_dry_file
 
   # TODO: Mock it explicitly by path
   before(:each) do
-    File.stub(:open => source_cred_file)
-    File.any_instance.stub(:puts => true)
-    Dir.stub(:mkdir => true)
-    SUSE::Connect::System.stub(:credentials => Credentials.new('dummy', 'tummy'))
+    allow(File).to receive(:open).and_return source_cred_file
+    allow_any_instance_of(File).to receive(:puts).and_return true
+    allow(Dir).to receive(:mkdir).and_return true
+    allow(SUSE::Connect::System).to receive(:credentials).and_return Credentials.new('dummy', 'tummy')
   end
 end
 


### PR DESCRIPTION
Please review the following changes:
  * 3795c85 fix rubocop offences
  * f0e3ee1 add enable_repository, disable_repository and repositories methods to migration script abstraction layer
  * 6fa2667 replace should_receive with expect to receive
  * 710eeaf fix rubocop offences
  * dca10c2 Use the new `:expect` syntax
  * 83785a3 don't set instance varibale :filesystem_root in test env, stub it
  * a05a9cc add unit test for Zypper.repositories
  * 434de0d add unit tests for enable_repository and disable_repository methods
  * d7e5d6a add enable_repository, disable_repository and repositories methods to Zypper class