### PR TITLE
Nicer message when the system has no activated base product

### DIFF
--- a/features/integration.feature
+++ b/features/integration.feature
@@ -4,6 +4,12 @@ Feature: SUSEConnect full stack integration testing
   This means we have to register a test machine against production server and examine all relevant data
 
   ### SUSEConnect cmd checks ###
+  Scenario: System registration requires a regcode
+    When I call SUSEConnect with '' arguments
+    Then the exit status should be 1
+    And the output should contain "Please register your system"
+
+
   Scenario: System registration
     When I call SUSEConnect with '--regcode VALID' arguments
     Then the exit status should be 0
@@ -16,12 +22,6 @@ Feature: SUSEConnect full stack integration testing
 
     And zypper should contain a service for base product
     And zypper should contain a repositories for base product
-
-
-  Scenario: System registration requires a regcode
-    When I call SUSEConnect with '' arguments
-    Then the exit status should be 1
-    And the output should contain "Please set the regcode parameter"
 
 
   Scenario: Free extension activation does not require regcode and activates the extension

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -32,11 +32,11 @@ module SUSE
           if @config.instance_data_file && @config.url_default?
             log.error 'Please use --instance-data only in combination with --url pointing to your SMT server'
             exit(1)
-          elsif @config.product.nil? && @config.token.nil? && @config.url_default?
-            log.error 'Please set the regcode parameter to register against SCC, or the url parameter to register against SMT'
-            exit(1)
           elsif @config.token && @config.instance_data_file
             log.error 'Please use either --regcode or --instance-data'
+            exit(1)
+          elsif @config.url_default? && !@config.token && !Status.new(@config).activated_base_product?
+            log.error 'Please register your system using the --regcode parameter, or provide the --url parameter to register against SMT.'
             exit(1)
           else
             Client.new(@config).register!

--- a/lib/suse/connect/status.rb
+++ b/lib/suse/connect/status.rb
@@ -26,6 +26,11 @@ module SUSE
         @known_activations ||= activations_from_server
       end
 
+      # Checks if system activations includes base product
+      def activated_base_product?
+        System.credentials? && activated_products.include?(Zypper.base_product)
+      end
+
       def print_extensions_list
         file = File.read File.join(File.dirname(__FILE__), 'templates/extensions_list.text.erb')
         template = ERB.new(file, 0, '-<>')

--- a/lib/suse/connect/status.rb
+++ b/lib/suse/connect/status.rb
@@ -7,6 +7,7 @@ module SUSE
     # and subscriptions as known by registration server.
     # At first it collects all installed products from the system, then it gets its `activations`
     # from the registration server. This information is merged and printed out.
+    # rubocop:disable ClassLength
     class Status
       attr_reader :client
 

--- a/lib/suse/connect/system.rb
+++ b/lib/suse/connect/system.rb
@@ -28,11 +28,6 @@ module SUSE
           !!credentials
         end
 
-        # Checks if system activations includes base product
-        def activated_base_product?
-          credentials? && Status.activated_products.include?(Zypper.base_product)
-        end
-
         def remove_credentials
           File.delete Credentials.system_credentials_file if credentials?
         end

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -76,8 +76,6 @@ describe SUSE::Connect::Status do
     end
   end
 
-
-
   describe '#print_product_statuses' do
     context 'text format' do
       it 'reads template from erb file' do

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -11,17 +11,13 @@ describe SUSE::Connect::Status do
     allow(Client).to receive(:new).and_return(client_double)
   end
 
-  describe '.client' do
-    it 'sets client class variable' do
+  describe '#client' do
+    it 'returns the client' do
       expect(subject.client).to eq client_double
-    end
-
-    it 'memoizes client class variable to avoid reinstantiation' do
-      expect(subject.client).to be client_double
     end
   end
 
-  describe '.activated_products' do
+  describe '#activated_products' do
     it 'memoizes activated_products by the first call' do
       allow(subject).to receive(:products_from_activations).and_return(:foobazbar)
       expect(subject.activated_products).to be subject.activated_products
@@ -33,7 +29,7 @@ describe SUSE::Connect::Status do
     end
   end
 
-  describe '.installed_products' do
+  describe '#installed_products' do
     it 'memoizes installed_products by the first call' do
       allow(subject).to receive(:products_from_zypper).and_return(:barbarbaz)
       expect(subject.installed_products).to be subject.installed_products
@@ -45,8 +41,8 @@ describe SUSE::Connect::Status do
     end
   end
 
-  describe '.known_activations' do
-    it 'memoizes known_activations by the first call' do
+  describe '#activations' do
+    it 'memoizes activations by the first call' do
       allow(subject).to receive(:activations_from_server).and_return(:superdo)
       expect(subject.activations).to be subject.activations
     end
@@ -56,6 +52,31 @@ describe SUSE::Connect::Status do
       subject.activations
     end
   end
+
+  describe '#activated_base_product?' do
+    it 'returns false if sytem does not have credentials' do
+      allow(System).to receive(:credentials?).and_return(false)
+      # We should not call activated_products if we don't have credentials
+      expect(subject).not_to receive(:activated_products)
+      expect(subject.activated_base_product?).to be false
+    end
+
+    it 'returns false if sytem has credentials but not activated' do
+      allow(System).to receive(:credentials?).and_return(true)
+      allow(Zypper).to receive(:base_product).and_return('base_product')
+      expect(subject).to receive(:activated_products).and_return([])
+      expect(subject.activated_base_product?).to be false
+    end
+
+    it 'returns true if sytem has credentials and activated' do
+      allow(System).to receive(:credentials?).and_return(true)
+      expect(Zypper).to receive(:base_product).and_return('base_product')
+      expect(subject).to receive(:activated_products).and_return(['base_product'])
+      expect(subject.activated_base_product?).to be true
+    end
+  end
+
+
 
   describe '#print_product_statuses' do
     context 'text format' do

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -76,29 +76,6 @@ describe SUSE::Connect::System do
     end
   end
 
-  describe '.activated_base_product?' do
-    it 'returns false if sytem does not have a credentials' do
-      allow(subject).to receive_messages(:credentials? => false)
-      expect(subject.activated_base_product?).to be false
-    end
-
-    it 'returns false if sytem has credentials but not activated' do
-      allow(subject).to receive_messages(credentials?: true)
-      allow(Zypper).to receive(:base_product)
-      expect(SUSE::Connect::Status).to receive(:activated_products).and_return([])
-      expect(subject.activated_base_product?).to be false
-    end
-
-    it 'returns true if sytem has credentials and activated' do
-      allow(subject).to receive_messages(credentials?: true)
-      product = Zypper::Product.new name: 'OpenSUSE'
-
-      expect(Zypper).to receive(:base_product).and_return(product)
-      expect(SUSE::Connect::Status).to receive(:activated_products).and_return([product])
-      expect(subject.activated_base_product?).to be true
-    end
-  end
-
   describe '.add_service' do
     before(:each) do
       allow(Zypper).to receive(:write_service_credentials)


### PR DESCRIPTION
Used to be:

```
# bin/SUSEConnect 
Please set the regcode parameter to register against SCC, or the url parameter to register against SMT

# bin/SUSEConnect -p sle-module-containers/12/x86_64
Error: SCC returned 'HTTP Token: Access denied.' (401)
```

Now:

```
# bin/SUSEConnect    
Please register your base system first using the --regcode parameter, or provide the --url parameter to register against SMT.

# bin/SUSEConnect -p sle-module-containers/12/x86_64
Please register your base system first using the --regcode parameter, or provide the --url parameter to register against SMT.
```