### PR TITLE
- Do not let zypper attempt to read products from remote locations

### DIFF
--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -18,7 +18,7 @@ module SUSE
         # Returns an array of all installed products, in which every product is
         # presented as a hash.
         def installed_products
-          zypper_out = call('--no-refresh --xmlout --non-interactive products -i', false)
+          zypper_out = call('--no-remote --no-refresh --xmlout --non-interactive products -i', false)
           xml_doc = REXML::Document.new(zypper_out, compress_whitespace: [])
           ary_of_products_hashes = xml_doc.root.elements['product-list'].elements.map(&:to_hash)
           ary_of_products_hashes.map {|hash| Product.new(hash) }

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -43,7 +43,7 @@ describe SUSE::Connect::Zypper do
         let(:xml) { File.read('spec/fixtures/product_valid_sle12sp0.xml') }
 
         before do
-          args = 'zypper --no-refresh --xmlout --non-interactive products -i'
+          args = 'zypper --no-remote --no-refresh --xmlout --non-interactive products -i'
           expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return([xml, '', status])
         end
 

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -16,7 +16,7 @@ describe SUSE::Connect::Zypper do
         let(:xml) { File.read('spec/fixtures/product_valid_sle11sp3.xml') }
 
         before do
-          args = 'zypper --no-refresh --xmlout --non-interactive products -i'
+          args = 'zypper --no-remote --no-refresh --xmlout --non-interactive products -i'
           expect(Open3).to receive(:capture3).with(shared_env_hash, args).and_return([xml, '', status])
         end
 


### PR DESCRIPTION
  when we are only interested in the products installed locally.