### PR TITLE
[no merge] Write registration certificate under /etc

### DIFF
--- a/lib/suse/connect/ssl_certificate.rb
+++ b/lib/suse/connect/ssl_certificate.rb
@@ -9,7 +9,7 @@ module SUSE
       extend Logger
 
       # where to save the imported certificate
-      SERVER_CERT_FILE = '/usr/share/pki/trust/anchors/registration_server.pem'
+      SERVER_CERT_FILE = '/etc/pki/trust/anchors/registration_server.pem'
 
       # script for updating the system certificates
       UPDATE_CERTIFICATES = '/usr/sbin/update-ca-certificates'

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,6 +1,6 @@
 module SUSE
   # Provides access to version number of a gem
   module Connect
-    VERSION = '0.2.37'
+    VERSION = '0.2.38'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 27 14:28:02 UTC 2016 - igonzalezsosa@suse.com
+
+- Update to 0.2.38:
+  - Use /etc/pki/trust/anchors to store the registration
+    certificate instead of the /usr/share/pki/trust/anchors
+    counterpart (bsc#989787).
+
+-------------------------------------------------------------------
 Tue Jun 21 10:10:12 UTC 2016 - hschmidt@suse.com
 
 - Update to 0.2.37:

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           SUSEConnect
-Version:        0.2.37
+Version:        0.2.38
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
I guess this change should be discussed before merging. While debugging [https://bugzilla.suse.com/show_bug.cgi?id=989787](bsc#989787) I realized that `/usr/share/pki/trust/anchors` is read-only in the installation media although it was read-write in SP1.

On the other hand, `/etc/pki/trust/anchors` is read-write. IMHO we should avoid writing stuff under /usr and use /etc for that. Opinions?

Thanks in advance!