### PR TITLE
Align help output with manpage 3447

### DIFF
--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -103,3 +103,5 @@ __SP1:__ `osc mr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP1:Update --no-c
 __SP2:__ `osc mr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP2:Update --no-cleanup`
 
 __SP3:__ (until it's released) `osc sr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP3:GA --no-cleanup`
+
+You can check the status of your requests [here](https://build.suse.de/project/requests/Devel:SCC:suseconnect).

--- a/SUSEConnect.8.ronn
+++ b/SUSEConnect.8.ronn
@@ -3,7 +3,7 @@ SUSEConnect(8) - SUSE Customer Center registration tool
 
 ## SYNOPSIS
 
-`SUSEConnect [<optional>...] -p PRODUCT
+`SUSEConnect [<optional>...] -p PRODUCT`
 
 ## DESCRIPTION
 
@@ -26,7 +26,7 @@ Manage subscriptions at [SUSE Customer Center][scc]
   * `-p`, `--product <PRODUCT>`:
     Activate PRODUCT. Defaults to the base SUSE Linux Enterprise product
     on this system. Product identifiers can be obtained with `--list-extensions`.
-    Format: <name>-<version>-<architecture>
+    Format: <name>/<version>/<architecture>
 
   * `-r`, `--regcode <REGCODE>`:
     Subscription registration code for the product to be registered.
@@ -42,10 +42,10 @@ Manage subscriptions at [SUSE Customer Center][scc]
 
   * `--instance-data <path to file>`:
     Path to the XML file holding the public key and instance data
-    for cloud registration with SMT`
+    for cloud registration with SMT.
 
   * `-e`, `--email <email>`:
-    Email address for product registration
+    Email address for product registration.
 
   * `--url <URL>`:
     URL of registration server (e.g. https://scc.suse.com).
@@ -73,13 +73,13 @@ Manage subscriptions at [SUSE Customer Center][scc]
     Path to the root folder, uses the same parameter for zypper.
 
   * `--version`:
-    Print program version
+    Print program version.
 
   * `--debug`:
-    Provide debug output
+    Provide debug output.
 
   * `-h`, `--help`:
-    Show help message
+    Show help message.
 
 ## EXIT CODES
   SUSEConnect sets the following exit codes:
@@ -112,7 +112,7 @@ Manage subscriptions at [SUSE Customer Center][scc]
 ## FILES
   * `/etc/SUSEConnect`:
     Configuration file containing server URL, regcode and language for
-    registration
+    registration.
 
 ## AUTHOR
   SUSE Linux Products GmbH <scc-feedback@suse.de>

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -89,15 +89,16 @@ module SUSE
         @opts = OptionParser.new
 
         @opts.separator 'Register SUSE Linux Enterprise installations with the SUSE Customer Center.'
-        @opts.separator 'Registration allows access to software repositories including updates,'
-        @opts.separator 'and allows online management of subscriptions and organizations'
+        @opts.separator 'Registration allows access to software repositories (including updates)'
+        @opts.separator 'and allows online management of subscriptions and organizations.'
         @opts.separator ''
         @opts.separator 'Manage subscriptions at https://scc.suse.com'
         @opts.separator ''
         @opts.on('-p', '--product [PRODUCT]', 'Activate PRODUCT. Defaults to the base SUSE Linux',
-                 '  Enterprise product on this system.',
-                 '  Product identifiers can be obtained with \'zypper products\'',
-                 '  Format: <internal name>/<version>/<architecture>') do |opt|
+                 'Enterprise product on this system.',
+                 'Product identifiers can be obtained with',
+                 '\'--list-extensions\'.',
+                 'Format: <internal name>/<version>/<architecture>') do |opt|
           check_if_param(opt, 'Please provide a product identifier')
           # rubocop:disable RegexpLiteral
           check_if_param((opt =~ /\S+\/\S+\/\S+/), 'Please provide the product identifier in this format: ' \
@@ -107,62 +108,72 @@ module SUSE
           @options[:product] = Remote::Product.new(identifier: identifier, version: version, arch: arch)
         end
 
-        @opts.on('-r', '--regcode [REGCODE]', 'Subscription registration code for the',
-                 '  product to be registered.',
-                 '  Relates that product to the specified subscription,',
-                 '  and enables software repositories for that product') do |opt|
+        @opts.on('-r', '--regcode [REGCODE]', 'Subscription registration code for the product to',
+                 'be registered.',
+                 'Relates that product to the specified subscription,',
+                 'and enables software repositories for that product.') do |opt|
           @options[:token] = opt
         end
 
-        @opts.on('-d', '--de-register', 'De-registers a system in order to not consume a subscription slot in SCC anymore',
-                 ' and removes all services installed by SUSEConnect') do |_opt|
+        @opts.on('-d', '--de-register', 'De-registers a system and removes all services',
+                 'installed by SUSEConnect. After de-registration,',
+                 'the system no longer consumes a subscription slot',
+                 'in SCC.') do |_opt|
           @options[:deregister] = true
         end
 
-        @opts.on('--instance-data  [path to file]', 'Path to the XML file holding the public key and instance data',
-                 '  for cloud registration with SMT') do |opt|
+        @opts.on('--instance-data  [path to file]', 'Path to the XML file holding the public key and',
+                 'instance data for cloud registration with SMT.') do |opt|
           check_if_param(opt, 'Please provide the path to your instance data file')
           @options[:instance_data_file] = opt
         end
 
-        @opts.on('-e', '--email <email>', 'email address for product registration') do |opt|
+        @opts.on('-e', '--email <email>', 'Email address for product registration.') do |opt|
           check_if_param(opt, 'Please provide an email address')
           @options[:email] = opt
         end
 
-        @opts.on('--url [URL]', 'URL of registration server (e.g. https://scc.suse.com).',
-                 '  Implies --write-config so that subsequent invocations use the same registration server.') do |opt|
+        @opts.on('--url [URL]', 'URL of registration server',
+                 '(e.g. https://scc.suse.com).',
+                 'Implies --write-config so that subsequent',
+                 'invocations use the same registration server.') do |opt|
           check_if_param(opt, 'Please provide registration server URL')
           @options[:url] = opt
           @options[:write_config] = true
         end
 
-        @opts.on('--namespace [NAMESPACE]', 'namespace option for use with SMT staging environments') do |opt|
+        @opts.on('--namespace [NAMESPACE]', 'Namespace option for use with SMT staging',
+                 'environments.') do |opt|
           check_if_param(opt, 'Please provide a namespace')
           @options[:namespace] = opt
         end
 
-        @opts.on('-s', '--status', 'get current system registration status in json format') do |_opt|
+        @opts.on('-s', '--status', 'Get current system registration status in json',
+                 'format.') do |_opt|
           @options[:status] = true
         end
 
-        @opts.on('--status-text', 'get current system registration status in text format') do |_opt|
+        @opts.on('--status-text', 'Get current system registration status in text',
+                 'format.') do |_opt|
           @options[:status_text] = true
         end
 
-        @opts.on('--list-extensions', 'list all extensions available for installation on this system') do |_opt|
+        @opts.on('--list-extensions', 'List all extensions and modules available for',
+                 'installation on this system.') do |_opt|
           @options[:list_extensions] = true
         end
 
-        @opts.on('--write-config', 'write options to config file at /etc/SUSEConnect') do |_opt|
+        @opts.on('--write-config', 'Write options to config file at /etc/SUSEConnect.') do |_opt|
           @options[:write_config] = true
         end
 
-        @opts.on('--cleanup', 'remove old system credentials and all zypper services installed by SUSEConnect') do |_opt|
+        @opts.on('--cleanup', 'Remove old system credentials and all zypper',
+                 'services installed by SUSEConnect.') do |_opt|
           @options[:cleanup] = true
         end
 
-        @opts.on('--rollback', 'revert the registration state in case of a failed migration') do |_opt|
+        @opts.on('--rollback', 'Revert the registration state in case of a failed',
+                 'migration.') do |_opt|
           log.info('> Beginning registration rollback. This can take some time...')
           SUSE::Connect::Migration.rollback
           exit 0
@@ -171,23 +182,24 @@ module SUSE
         @opts.separator ''
         @opts.separator 'Common options:'
 
-        @opts.on('--root [PATH]', 'Path to the root folder, uses the same parameter for zypper.') do |opt|
+        @opts.on('--root [PATH]', 'Path to the root folder, uses the same parameter',
+                 'for zypper.') do |opt|
           check_if_param(opt, 'Please provide path parameter')
           @options[:filesystem_root] = opt
           SUSE::Connect::System.filesystem_root = opt
         end
 
-        @opts.on('--version', 'print program version') do
+        @opts.on('--version', 'Print program version.') do
           puts VERSION
           exit
         end
 
-        @opts.on('--debug', 'provide debug output') do |opt|
+        @opts.on('--debug', 'Provide debug output.') do |opt|
           @options[:debug] = opt
           SUSE::Connect::GlobalLogger.instance.log.level = ::Logger::DEBUG if opt
         end
 
-        @opts.on_tail('-h', '--help', 'show this message') do
+        @opts.on_tail('-h', '--help', 'Show this message.') do
           puts @opts
           exit
         end

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,6 +1,6 @@
 module SUSE
   # Provides access to version number of a gem
   module Connect
-    VERSION = '0.2.41'
+    VERSION = '0.2.42'
   end
 end

--- a/package/.osc/_files
+++ b/package/.osc/_files
@@ -1,8 +1,8 @@
-<directory name="SUSEConnect" rev="110" srcmd5="08aacd8cb3b8d10ee6fb3cf564c3fe3f" vrev="4">
-  <entry md5="c0d77d6acb80e8a614e41f0e2787a662" mtime="1485860696" name="SUSEConnect.5.gz" size="707" />
-  <entry md5="3657bc4a06fc7e2a5d8e1761738cff73" mtime="1485860696" name="SUSEConnect.8.gz" size="1813" />
-  <entry md5="bfc70f7eade748db1b2d67e9b19b3d89" mtime="1486558221" name="SUSEConnect.changes" size="17044" />
+<directory name="SUSEConnect" rev="111" srcmd5="dcf7ae6d1661ea9c821c31d1cad1af6b" vrev="1">
+  <entry md5="d6e1825e27691985eaac3c43589b2404" mtime="1488535195" name="SUSEConnect.5.gz" size="707" />
+  <entry md5="8e762d7aafbbcdb7c5c3952d01dde645" mtime="1488535195" name="SUSEConnect.8.gz" size="1808" />
+  <entry md5="3008b7c26909ac7b21305feecbb69b50" mtime="1488535195" name="SUSEConnect.changes" size="17200" />
   <entry md5="0ec806db52d249028059602f052dad98" mtime="1407413878" name="SUSEConnect.example" size="377" />
-  <entry md5="7a562e3a8e69b10b60d89f4e9831a12f" mtime="1475746609" name="SUSEConnect.spec" size="4328" />
-  <entry md5="27a9bcbe43a9b9d5af619eaa027a5f1d" mtime="1486558222" name="suse-connect-0.2.41.gem" size="35840" />
+  <entry md5="06058659f2c75e868aa2ed35dff5cfda" mtime="1488535195" name="SUSEConnect.spec" size="4328" />
+  <entry md5="232757fd6a0f9eb631fb58af41623df3" mtime="1488535196" name="suse-connect-0.2.42.gem" size="35840" />
 </directory>

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,11 +1,16 @@
 -------------------------------------------------------------------
+Fri Mar  3 09:46:25 UTC 2017 - thutterer@suse.com
+
+- Update to 0.2.42:
+  - Better error message for network request failure (bsc#982630)
+  - Fix error message for --product with malformed identifier (bsc#1018190)
+  - Fix some errors and formatting in manpages and help output
+
+-------------------------------------------------------------------
 Thu Oct  6 08:59:28 UTC 2016 - thutterer@suse.com
 
 - Update to 0.2.41:
-  - Better error message for network request failure (bsc#982630)
   - Better error message for --list-extensions on unregistered systems
-  - Fix error message for --product with malformed identifier (bsc#1018190)
-  - Fix some errors and formatting in manpages
 
 -------------------------------------------------------------------
 Tue Sep 13 12:06:22 UTC 2016 - hschmidt@suse.com

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           SUSEConnect
-Version:        0.2.41
+Version:        0.2.42
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -296,7 +296,7 @@ describe SUSE::Connect::Cli do
     it 'outputs help on help flag with no line longer than 80 characters' do
       argv = %w{--help}
       expect_any_instance_of(subject).to receive(:puts) do |option_parser|
-        expect(option_parser.instance_variable_get(:@opts).to_s.split("\n").collect(&:length).max).to be <= 80
+        expect(option_parser.instance_variable_get(:@opts).to_s.split("\n").map(&:length).max).to be <= 80
       end
       subject.new(argv)
     end

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -293,9 +293,11 @@ describe SUSE::Connect::Cli do
       subject.new(argv)
     end
 
-    it 'output help on help flag' do
+    it 'outputs help on help flag with no line longer than 80 characters' do
       argv = %w{--help}
-      expect_any_instance_of(subject).to receive(:puts)
+      expect_any_instance_of(subject).to receive(:puts) do |option_parser|
+        expect(option_parser.instance_variable_get(:@opts).to_s.split("\n").collect(&:length).max).to be <= 80
+      end
       subject.new(argv)
     end
 


### PR DESCRIPTION
this is a follow-up after #283 

- there were a few formatting things left to do in the manpage.
- the `--help` output was not yet aligned with the manpage changes.
- the line length of `--help` was >120. now we have a spec to make sure its never larger than a 80 chars.