### PR TITLE
Update zypper before running tests

### DIFF
--- a/docker/prophet_tests.sh
+++ b/docker/prophet_tests.sh
@@ -1,4 +1,8 @@
 #!/bin/sh -xe
+
+# make sure we always test with the latest version of zypper
+zypper --non-interactive up zypper
+
 cd /tmp/connect && su nobody -c rspec
 cd /tmp/connect && su nobody -c rubocop
 cd /tmp/connect && cucumber


### PR DESCRIPTION
This avoids situations like #298  where a new Connect feature depends on a zypper version newer than the one in the Docker image.
Also I think it's good practice to test with the latest released updates of dependencies, because this is closer to what a real user of SLES would do when he/she updates the Connect package and pulls in the new zypper versions.