### PR TITLE
Use cucumber 2.4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ group :test do
   gem 'webmock', '~> 1.21.0'
   gem 'http', '~> 0.8.12'
   gem 'aruba', '~> 0.7.4'
+  gem 'cucumber', '~> 2.4.0'
 end


### PR DESCRIPTION
The cucumber 3.x line is not supported on ruby 2.x, so we lock it to a
supported version.