### PR TITLE
Make target_base_product mandatory in YaST API / Card 4616

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,6 +1,6 @@
 module SUSE
   # Provides access to version number of a gem
   module Connect
-    VERSION = '0.3.5'
+    VERSION = '0.3.6'
   end
 end

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -171,10 +171,10 @@ module SUSE
         # @return [Array <Array <OpenStruct>>] the list of possible migration paths for the given {Product}s,
         #   where a migration path is an array of OpenStruct objects with the attributes
         #   identifier, arch, version, and release_type
-        def system_offline_migrations(installed_products, target_base_product = nil, client_params = {})
+        def system_offline_migrations(installed_products, target_base_product, client_params = {})
           config = SUSE::Connect::Config.new.merge!(client_params)
-          target_base_product = Remote::Product.new(target_base_product.to_h) if target_base_product
-          args = { target_base_product: target_base_product, kind: :offline }.reject { |_, v| v.nil? }
+          target_base_product = Remote::Product.new(target_base_product.to_h)
+          args = { target_base_product: target_base_product, kind: :offline }
 
           Client.new(config).system_migrations(installed_products, args).map { |a| a.map(&:to_openstruct) }
         end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 28 13:29:20 UTC 2017 - hschmidt@suse.com
+
+- Update to 0.3.6
+  - Make target_base_product parameter mandatory.
+
+-------------------------------------------------------------------
 Mon Dec 18 14:56:58 UTC 2017 - hschmidt@suse.com
 
 - Update to 0.3.5

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           SUSEConnect
-Version:        0.3.5
+Version:        0.3.6
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -313,18 +313,7 @@ describe SUSE::Connect::YaST do
   end
 
   describe '.system_offline_migrations' do
-    shared_examples 'returning migration paths' do
-      it 'returns the result as an array of arrays of OpenStructs' do
-        client_double = instance_double(Client)
-        allow(Client).to receive(:new).with(anything).and_return(client_double)
-
-        product_attributes = { identifier: 'SLES', version: '15', arch: 'x86_64', release_type: 'CD' }
-        allow(client_double).to receive(:system_migrations)
-          .and_return([[ Remote::Product.new(product_attributes) ]])
-
-        expect(subject).to eq([[ OpenStruct.new(product_attributes) ]])
-      end
-    end
+    subject { described_class.system_offline_migrations(installed_products_openstruct, target_base_product, client_params) }
 
     let(:installed_products) do
       [
@@ -336,38 +325,27 @@ describe SUSE::Connect::YaST do
     let(:client_params) { { foo: 'oink' } }
     let(:target_base_product) { OpenStruct.new(identifier: 'SLES', version: '15', arch: 'x86_64', release_type: 'CD') }
 
-    context 'with a specified target_base_product' do
-      subject { described_class.system_offline_migrations installed_products_openstruct, target_base_product, client_params }
+    include_examples 'config initializer'
 
-      include_examples 'config initializer'
-      include_examples 'returning migration paths'
+    it 'returns the result as an array of arrays of OpenStructs' do
+      client_double = instance_double(Client)
+      allow(Client).to receive(:new).with(anything).and_return(client_double)
 
-      it 'calls Client#system_migrations with the products list, the target product, and kind :offline' do
-        client_double = instance_double(Client)
-        allow(Client).to receive(:new).with(anything).and_return(client_double)
+      product_attributes = { identifier: 'SLES', version: '15', arch: 'x86_64', release_type: 'CD' }
+      allow(client_double).to receive(:system_migrations)
+        .and_return([[ Remote::Product.new(product_attributes) ]])
 
-        expect(client_double).to receive(:system_migrations)
-          .with(installed_products_openstruct, kind: :offline, target_base_product: Remote::Product.new(target_base_product.to_h))
-          .and_return([])
-        subject
-      end
+      expect(subject).to eq([[ OpenStruct.new(product_attributes) ]])
     end
 
-    context 'with no specified target_base_product' do
-      subject { described_class.system_offline_migrations installed_products_openstruct, nil, client_params }
+    it 'calls Client#system_migrations with the products list, the target product, and kind :offline' do
+      client_double = instance_double(Client)
+      allow(Client).to receive(:new).with(anything).and_return(client_double)
 
-      include_examples 'config initializer'
-      include_examples 'returning migration paths'
-
-      it 'calls Client#system_migrations with the products list and kind :offline' do
-        client_double = instance_double(Client)
-        allow(Client).to receive(:new).with(anything).and_return(client_double)
-
-        expect(client_double).to receive(:system_migrations)
-          .with(installed_products_openstruct, kind: :offline)
-          .and_return([])
-        subject
-      end
+      expect(client_double).to receive(:system_migrations)
+        .with(installed_products_openstruct, kind: :offline, target_base_product: Remote::Product.new(target_base_product.to_h))
+        .and_return([])
+      subject
     end
   end
 


### PR DESCRIPTION
The parameter is mandatory in the Connect API, so YaST needs to provide it.