### PR TITLE
Remove refresh services and fix ci

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,8 +7,8 @@ require 'cucumber/rspec/doubles'
 OPTIONS = YAML.load_file(File.join(__dir__, 'environments.yml')).fetch(ENV.fetch('PRODUCT'))
 
 Before('@slow_process') do
-  aruba.config.io_wait_timeout = 90
-  aruba.config.exit_timeout = 90
+  aruba.config.io_wait_timeout = 180
+  aruba.config.exit_timeout = 120
 end
 
 Before('@libzypplocked') do

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -46,11 +46,8 @@ module SUSE
         service = activate_product(product, @config.email)
 
         System.add_service(service)
+        Zypper.install_release_package(product.identifier) if install_release_package
 
-        if install_release_package
-          Zypper.refresh_services
-          Zypper.install_release_package(product.identifier)
-        end
         print_success_message(product)
       end
 

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -352,7 +352,6 @@ describe SUSE::Connect::Client do
       expect(subject).to receive(:activate_product).with(product, fake_email).and_return service_stub
       expect(System).to receive(:add_service).with(service_stub)
 
-      expect(Zypper).to receive(:refresh_services)
       expect(Zypper).to receive(:install_release_package).with(product.identifier)
 
       subject.register_product(product)
@@ -362,7 +361,6 @@ describe SUSE::Connect::Client do
       expect(subject).to receive(:activate_product).with(product, fake_email).and_return service_stub
       expect(System).to receive(:add_service).with(service_stub)
 
-      expect(Zypper).not_to receive(:refresh_services)
       expect(Zypper).not_to receive(:install_release_package)
 
       subject.register_product(product, false)
@@ -371,7 +369,6 @@ describe SUSE::Connect::Client do
     it 'informs the user about progress' do
       allow(subject).to receive(:activate_product)
       allow(System).to receive(:add_service)
-      allow(Zypper).to receive(:refresh_services)
       allow(Zypper).to receive(:install_release_package)
 
       expect(string_logger).to receive(:info).with('Registered SLES 15 x86_64')


### PR DESCRIPTION
Actual problem: The CI is facing problem with poor IO throughput from time to time. This multiplies when tests are running in parallel (This is also the reason why this is not happening when cucumber runs on a local machine). That's why its important to make sure the tests run long enough to actually pass.

1) Remove rendunant service refresh
  Services are already refreshed when added, so no need to refresh again -> less IO

2) Increase the timeout
  Make sure the tests can actually pass. 90 seconds seems a little bit short, at least when the CI server   is running tests in parallel. By adding different numbers make sure the test fails because of exit timeout and not by closing the handles to the running process. -> more time for the tests

Since this is hard to prove and there is no way to tell this will actually solve the problem once and for all, look at this as a first try to get one step further. My test runs where all green, I hope this stays when pushing this!