### PR TITLE
Add Leap as submit target; add note about bsc

### DIFF
--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -40,6 +40,8 @@ Please also update `package/SUSEConnect.changes` file with a list of new feature
 osc vc
 ```
 
+**Note:** The changelog entry **requires** a reference to a Bugzilla bug (in the form of `bsc#1234`), otherwise maintenance requests will be declined. Even if no bug exists for the particular code change, you need to create one and then reference it here. This is the only way that the patches can appear in the patch finder.
+
 After you've commited your sources, make sure that a new git tag (looking like `v0.3.88`) has been also created and pushed. It is highly advised to use [signed tags](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work); use `git tag -s v0.3.88 -m "Version 0.3.88"` to create those.
 
 ## Step 4. Prepare the files for building the package
@@ -111,8 +113,9 @@ osc -A https://api.suse.de sr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-15:GA -
 To submit the updated package as a maintenance update to maintained SLES versions:
 
 ```bash
-osc -A https://api.suse.de mr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP2:Update --no-cleanup
-osc -A https://api.suse.de mr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP3:Update --no-cleanup
+osc -A https://api.suse.de sr systemsmanagement:SCC SUSEConnect openSUSE:Leap:15.0:Update --no-cleanup
+osc -A https://api.suse.de sr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP2:Update --no-cleanup
+osc -A https://api.suse.de sr Devel:SCC:suseconnect SUSEConnect SUSE:SLE-12-SP3:Update --no-cleanup
 ```
 
 You can check the status of your requests [here](https://build.opensuse.org/package/requests/systemsmanagement:SCC/SUSEConnect) and [here](https://build.suse.de/package/requests/Devel:SCC:suseconnect/SUSEConnect).


### PR DESCRIPTION
Also, it's nicer to use `sr` rather than `mr`.
Strictly speaking, once a product goes into maintenance, you need to create a "maintenance request" (mr) rather than a "submit request" (sr), but the `sr` command will automatically transform the request into a maintenance request. Additionally, `sr` will automatically fill out the commit message based on the changelog, but `mr` will not, which is annoying.