### PR TITLE
Improvements to Zypper#add_service documentation

### DIFF
--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -88,6 +88,7 @@ module SUSE
         # @param service_name [String] Alias-mnemonic with which zypper should add this service
         # @return [TrueClass]
         #
+        # @see https://doc.opensuse.org/projects/libzypp/HEAD/zypp-services.html#services-remote ZYpp Services Documentation
         # @todo TODO: introduce Product class
         def add_service(service_url, service_name)
           # INFO: Remove old service which could be modified by a customer

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -84,7 +84,7 @@ module SUSE
           xml_doc.elements.to_a('stream/repo-list/repo').map { |r| r.to_hash.merge!(url: r.elements['url'].text) }
         end
 
-        # @param service_url [String] url to appropriate repomd.xml to be fed to zypper
+        # @param service_url [String] url to appropriate repoindex.xml to be fed to zypper
         # @param service_name [String] Alias-mnemonic with which zypper should add this service
         # @return [TrueClass]
         #


### PR DESCRIPTION
Some inaccuracies like services having a 'repomd.xml', and pointing back to the official ZYpp documentation.