### PR TITLE
Add cloud_provider to hwinfo

### DIFF
--- a/lib/suse/connect/hwinfo/arm64.rb
+++ b/lib/suse/connect/hwinfo/arm64.rb
@@ -8,7 +8,8 @@ class SUSE::Connect::HwInfo::ARM64 < SUSE::Connect::HwInfo::Base
         sockets: sockets,
         hypervisor: hypervisor,
         arch: arch,
-        uuid: uuid
+        uuid: uuid,
+        cloud_provider: cloud_provider
       }
     end
 

--- a/lib/suse/connect/hwinfo/base.rb
+++ b/lib/suse/connect/hwinfo/base.rb
@@ -42,6 +42,15 @@ module SUSE::Connect::HwInfo
       def arm64?
         arch == 'aarch64'
       end
+
+      def cloud_provider
+        regex = /(Version: .*(amazon)|Manufacturer: (Google)|Manufacturer: (Microsoft) Corporation)/
+        matches = execute('dmidecode -t system', false).match(regex).to_a[2..4].to_a.compact
+        return nil unless matches.length == 1
+        matches[0].capitalize
+      rescue SUSE::Connect::SystemCallError
+        nil
+      end
     end
   end
 end

--- a/lib/suse/connect/hwinfo/s390.rb
+++ b/lib/suse/connect/hwinfo/s390.rb
@@ -8,7 +8,8 @@ class SUSE::Connect::HwInfo::S390 < SUSE::Connect::HwInfo::Base
         sockets: sockets,
         hypervisor: hypervisor,
         arch: arch,
-        uuid: uuid
+        uuid: uuid,
+        cloud_provider: cloud_provider
       }
     end
 

--- a/lib/suse/connect/hwinfo/x86.rb
+++ b/lib/suse/connect/hwinfo/x86.rb
@@ -8,7 +8,8 @@ class SUSE::Connect::HwInfo::X86 < SUSE::Connect::HwInfo::Base
         sockets: sockets,
         hypervisor: hypervisor,
         arch: arch,
-        uuid: uuid
+        uuid: uuid,
+        cloud_provider: cloud_provider
       }
     end
 

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.11'
+    VERSION = '0.3.12'
   end
 end

--- a/lib/tasks/package.rake
+++ b/lib/tasks/package.rake
@@ -3,7 +3,7 @@ require 'English'
 
 def version_from_spec(spec_glob)
   version = `grep '^Version:' #{spec_glob}`
-  version[/(\d\.\d\.\d)/, 0]
+  version[/(\d+\.\d+\.\d+)/, 0]
 end
 
 def upstream_file(name, file_type, obs_project, package_name)

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep  5 12:21:39 UTC 2018 - tmuntaner@suse.com
+
+- Update to 0.3.12
+  - Detect if system is in cloud provider (AWS/Google/Azure)
+    (fate#320935)
+
+-------------------------------------------------------------------
 Tue Jun 19 15:58:46 UTC 2018 - tschmidt@suse.com
 
 - Fix .spec file for running SUSEConnect on Fedora28

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.11
+Version:        0.3.12
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/hwinfo/arm64_spec.rb
+++ b/spec/connect/hwinfo/arm64_spec.rb
@@ -5,11 +5,13 @@ describe SUSE::Connect::HwInfo::ARM64 do
   subject { SUSE::Connect::HwInfo::ARM64 }
   let(:success) { double('Process Status', exitstatus: 0) }
   let(:lscpu) { File.read(File.join(fixtures_dir, 'lscpu_phys.txt')) }
+  let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_aws.txt')) }
   include_context 'shared lets'
 
   before :each do
     allow(SUSE::Connect::System).to receive(:hostname).and_return('test')
     allow(Open3).to receive(:capture3).with(shared_env_hash, 'lscpu').and_return([lscpu, '', success])
+    allow(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -t system').and_return([dmidecode, '', success])
   end
 
   after(:each) do
@@ -18,8 +20,8 @@ describe SUSE::Connect::HwInfo::ARM64 do
 
   it 'returns a hwinfo hash for aarm64 systems' do
     allow(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['aarch64', '', success])
-    expect(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -s system-uuid').and_return(['uuid', '', success])
-    expect(Open3).to receive(:capture3).with(shared_env_hash, 'systemd-detect-virt -v').and_return(['none', '', success])
+    allow(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -s system-uuid').and_return(['uuid', '', success])
+    allow(Open3).to receive(:capture3).with(shared_env_hash, 'systemd-detect-virt -v').and_return(['none', '', success])
 
     hwinfo = subject.hwinfo
     expect(hwinfo[:hostname]).to eq 'test'
@@ -28,6 +30,7 @@ describe SUSE::Connect::HwInfo::ARM64 do
     expect(hwinfo[:hypervisor]).to eq nil
     expect(hwinfo[:arch]).to eq 'aarch64'
     expect(hwinfo[:uuid]).to eq 'uuid'
+    expect(hwinfo[:cloud_provider]).to eq 'Amazon'
   end
 
   it 'parses output of lscpu and returns hash' do

--- a/spec/connect/hwinfo/base_spec.rb
+++ b/spec/connect/hwinfo/base_spec.rb
@@ -2,11 +2,54 @@ require 'spec_helper'
 
 describe SUSE::Connect::HwInfo::Base do
   subject { SUSE::Connect::HwInfo::Base }
-  let(:success) { double('Process Status', exitstatus: 0) }
+  let(:exit_status) { double('Process Status', exitstatus: 0) }
+  let(:dmidecode) { '' }
   include_context 'shared lets'
 
   after(:each) do
     SUSE::Connect::HwInfo::Base.instance_variable_set('@arch', nil)
+  end
+
+  describe '#cloud_provider' do
+    before(:each) do
+      allow(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -t system').and_return([dmidecode, '', exit_status])
+    end
+
+    it 'handles non-cloud providers' do
+      expect(subject.cloud_provider).to be_nil
+    end
+
+    context 'run with error' do
+      let(:exit_status) { double('Process Status', exitstatus: 1) }
+
+      it 'defaults to nil with error' do
+        expect(subject.cloud_provider).to be_nil
+      end
+    end
+
+    context 'AWS hypervisors' do
+      let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_aws.txt')) }
+
+      it 'can detect an amazon hypervisor' do
+        expect(subject.cloud_provider).to eq('Amazon')
+      end
+    end
+
+    context 'Google hypervisors' do
+      let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_google.txt')) }
+
+      it 'can detect an google hypervisor' do
+        expect(subject.cloud_provider).to eq('Google')
+      end
+    end
+
+    context 'Azure hypervisors' do
+      let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_azure.txt')) }
+
+      it 'can detect an microsoft hypervisor' do
+        expect(subject.cloud_provider).to eq('Microsoft')
+      end
+    end
   end
 
   describe '#info' do
@@ -74,43 +117,43 @@ describe SUSE::Connect::HwInfo::Base do
 
   describe '#arch' do
     it 'returns the system architecture' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', exit_status])
       expect(subject.arch).to eql 'blob'
     end
   end
 
   describe '#x86?' do
     it 'returns true if the system architecture is x86 or x86_64' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['x86_64', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['x86_64', '', exit_status])
       expect(subject.x86?).to eql true
     end
 
     it 'returns false if the system architecture is not x86 or x86_64' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', exit_status])
       expect(subject.x86?).to eql false
     end
   end
 
   describe '#s390?' do
     it 'returns true if the system architecture is s390x' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['s390x', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['s390x', '', exit_status])
       expect(subject.s390?).to eql true
     end
 
     it 'returns false if the system architecture is not s390x' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', exit_status])
       expect(subject.s390?).to eql false
     end
   end
 
   describe '#arm64?' do
     it 'returns true if the system architecture is aarch64' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['aarch64', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['aarch64', '', exit_status])
       expect(subject.arm64?).to eql true
     end
 
     it 'returns false if the system architecture is not aarch64' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', success])
+      expect(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['blob', '', exit_status])
       expect(subject.s390?).to eql false
     end
   end

--- a/spec/connect/hwinfo/s390_spec.rb
+++ b/spec/connect/hwinfo/s390_spec.rb
@@ -5,12 +5,14 @@ describe SUSE::Connect::HwInfo::S390 do
   subject { SUSE::Connect::HwInfo::S390 }
   let(:read_values) { File.read(File.join(fixtures_dir, 'read_values_s.txt')) }
   let(:success) { double('Process Status', exitstatus: 0) }
+  let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_aws.txt')) }
   include_context 'shared lets'
 
   before :each do
     allow(Open3).to receive(:capture3).with(shared_env_hash, 'uname -i').and_return(['s390x', '', success])
     allow(SUSE::Connect::System).to receive(:hostname).and_return('test')
     allow(Open3).to receive(:capture3).with(shared_env_hash, 'read_values -s').and_return([read_values, '', success])
+    allow(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -t system').and_return([dmidecode, '', success])
   end
 
   after(:each) do
@@ -41,6 +43,7 @@ describe SUSE::Connect::HwInfo::S390 do
       expect(hwinfo[:hypervisor]).to eq 'z/VM 6.1.0'
       expect(hwinfo[:arch]).to eq 's390x'
       expect(hwinfo[:uuid]).to eq nil
+      expect(hwinfo[:cloud_provider]).to eq 'Amazon'
     end
 
     it 'returns system hypervisor' do
@@ -64,6 +67,7 @@ describe SUSE::Connect::HwInfo::S390 do
       expect(hwinfo[:hypervisor]).to eq nil
       expect(hwinfo[:arch]).to eq 's390x'
       expect(hwinfo[:uuid]).to eq nil
+      expect(hwinfo[:cloud_provider]).to eq 'Amazon'
     end
 
     it 'returns no hypervisor when running on an LPAR' do

--- a/spec/connect/hwinfo/x86_spec.rb
+++ b/spec/connect/hwinfo/x86_spec.rb
@@ -5,11 +5,13 @@ describe SUSE::Connect::HwInfo::X86 do
   subject { SUSE::Connect::HwInfo::X86 }
   let(:success) { double('Process Status', exitstatus: 0) }
   let(:lscpu) { File.read(File.join(fixtures_dir, 'lscpu_phys.txt')) }
+  let(:dmidecode) { File.read(File.join(fixtures_dir, 'dmidecode_aws.txt')) }
   include_context 'shared lets'
 
   before :each do
     allow(SUSE::Connect::System).to receive(:hostname).and_return('test')
     allow(Open3).to receive(:capture3).with(shared_env_hash, 'lscpu').and_return([lscpu, '', success])
+    allow(Open3).to receive(:capture3).with(shared_env_hash, 'dmidecode -t system').and_return([dmidecode, '', success])
   end
 
   after(:each) do
@@ -27,6 +29,7 @@ describe SUSE::Connect::HwInfo::X86 do
     expect(hwinfo[:hypervisor]).to eq nil
     expect(hwinfo[:arch]).to eq 'x86_64'
     expect(hwinfo[:uuid]).to eq 'uuid'
+    expect(hwinfo[:cloud_provider]).to eq 'Amazon'
   end
 
   it 'parses output of lscpu and returns hash' do

--- a/spec/fixtures/dmidecode_aws.txt
+++ b/spec/fixtures/dmidecode_aws.txt
@@ -1,0 +1,18 @@
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Xen
+	Product Name: HVM domU
+	Version: 4.2.amazon
+	Serial Number: ec266d00-0a79-7089-68d5-82cc396381c1
+	UUID: EC266D00-0A79-7089-68D5-82CC396381C1
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected

--- a/spec/fixtures/dmidecode_azure.txt
+++ b/spec/fixtures/dmidecode_azure.txt
@@ -1,0 +1,27 @@
+# dmidecode 3.0
+Getting SMBIOS data from sysfs.
+SMBIOS 2.3 present.
+
+Handle 0x0001, DMI type 1, 25 bytes
+System Information
+	Manufacturer: Microsoft Corporation
+	Product Name: Virtual Machine
+	Version: 7.0
+	Serial Number: 0000-0005-0960-9066-4444-7097-88
+	UUID: 75F3B846-6985-9C4B-835F-12D4A8C73BA7
+	Wake-up Type: Power Switch
+
+Handle 0x004E, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: To Be Filled By O.E.M.
+	Option 2: To Be Filled By O.E.M.
+	Option 3: To Be Filled By O.E.M.
+
+Handle 0x014F, DMI type 23, 13 bytes
+System Reset
+	Status: Disabled
+	Watchdog Timer: Not Present
+
+Handle 0x0150, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected

--- a/spec/fixtures/dmidecode_google.txt
+++ b/spec/fixtures/dmidecode_google.txt
@@ -1,0 +1,18 @@
+# dmidecode 3.0
+Scanning /dev/mem for entry point.
+SMBIOS 2.4 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Google
+	Product Name: Google Compute Engine
+	Version: Not Specified
+	Serial Number: GoogleCloud-28570BE051B627017F196DB87226F476
+	UUID: 28570BE0-51B6-2701-7F19-6DB87226F476
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected


### PR DESCRIPTION
For internal data mining purposes, we would like to know the usage of
BYOS in public clouds. The additional field `cloud_provider` will show
what public cloud the system is located in by looking at dmidecode.