### PR TITLE
Don't fail when trying to parse an empty body

### DIFF
--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -42,7 +42,7 @@ osc vc
 
 **Note:** The changelog entry **requires** a reference to a Bugzilla bug (in the form of `bsc#1234`), otherwise maintenance requests will be declined. Even if no bug exists for the particular code change, you need to create one and then reference it here. This is the only way that the patches can appear in the patch finder.
 
-After you've commited your sources, make sure that a new git tag (looking like `v0.3.88`) has been also created and pushed. It is highly advised to use [signed tags](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work); use `git tag -s v0.3.88 -m "Version 0.3.88"` to create those.
+After you've committed your sources, make sure that a new git tag (looking like `v0.3.88`) has been also created and pushed. It is highly advised to use [signed tags](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work); use `git tag -s v0.3.88 -m "Version 0.3.88"` to create those.
 
 ## Step 4. Prepare the files for building the package
 

--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -59,14 +59,14 @@ module SUSE
         request = VERB_TO_CLASS[method].new(path)
         add_headers(request)
 
-        request.body               = params.to_json unless params.empty?
-        response                   = @http.request(request)
-        body                       = JSON.parse(response.body) if response.body
+        request.body  = params.to_json unless params.empty?
+        response      = @http.request(request)
+        response_body = JSON.parse(response.body) unless response.body.to_s.empty?
 
         OpenStruct.new(
           code: response.code.to_i,
           headers: response.to_hash,
-          body: body,
+          body: response_body,
           http_message: response.message,
           success: response.is_a?(Net::HTTPSuccess)
         )

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -4,6 +4,7 @@ Wed Sep  5 12:21:39 UTC 2018 - tmuntaner@suse.com
 - Update to 0.3.12
   - Detect if system is in cloud provider (AWS/Google/Azure)
     (fate#320935)
+- Don't fail when trying to parse an empty body. Fixes bsc#1098220
 
 -------------------------------------------------------------------
 Tue Jun 19 15:58:46 UTC 2018 - tschmidt@suse.com

--- a/spec/connect/connection_spec.rb
+++ b/spec/connect/connection_spec.rb
@@ -99,35 +99,45 @@ describe SUSE::Connect::Connection do
     end
 
     before do
-      allow(connection.http).to receive(:request).and_return(OpenStruct.new(body: 'bodyofostruct'))
-      allow(JSON).to receive_messages(parse: { '1' => '2' })
+      allow(connection.http).to receive(:request).and_return(OpenStruct.new(body: '{ "test": "body" }'))
     end
 
-    context :get_request do
+    context 'with a get request' do
       it 'takes Net::HTTP::Get class to build request' do
         expect(Net::HTTP::Get).to receive(:new).and_call_original
         connection.send(:json_request, :get, '/api/v1/megusta')
       end
     end
 
-    context :post_request do
+    context 'with a post request' do
       it 'takes Net::HTTP::Post class to build request' do
         expect(Net::HTTP::Post).to receive(:new).and_call_original
         connection.send(:json_request, :post, '/api/v1/megusta')
       end
     end
 
-    context :put_request do
+    context 'with a put request' do
       it 'takes Net::HTTP::Put class to build request' do
         expect(Net::HTTP::Put).to receive(:new).and_call_original
         connection.send(:json_request, :put, '/api/v1/megusta')
       end
     end
 
-    context :delete_request do
+    context 'with a delete request' do
       it 'takes Net::HTTP::Delete class to build request' do
         expect(Net::HTTP::Delete).to receive(:new).and_call_original
         connection.send(:json_request, :delete, '/api/v1/megusta')
+      end
+    end
+
+    context 'with an empty body response' do
+      before do
+        allow(connection.http).to receive(:request).and_return(OpenStruct.new(body: ''))
+      end
+
+      it 'does not fail to parse the body' do
+        expect(Net::HTTP::Get).to receive(:new).and_call_original
+        connection.send(:json_request, :get, '/api/v1/megusta')
       end
     end
   end


### PR DESCRIPTION
Our code only parsed the response body when the body is not-nil -- but
it can receive an empty body ("") which is invalid JSON and can't be
parsed.
This is the case for example when an SMT server returns 404.

Fixes bsc#1098220