### PR TITLE
Allow installing openssl 1.0 without removing SUSEConnect

### DIFF
--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 23 15:52:51 UTC 2018 - hschmidt@suse.com
+
+- Changed "openssl" recommendation to "openssl(cli)"
+  on SLE 12 SP3+ and SLE 15+ (bsc#1101470).
+
+-------------------------------------------------------------------
 Mon Oct 22 15:59:04 UTC 2018 - hschmidt@suse.com
 
 - Update to 0.3.14

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -39,7 +39,12 @@ Requires:       zypper
 Recommends:     gawk
 Recommends:     gpg2
 Recommends:     grep
+# Allows for installing openssl 1.0 without needing to remove SUSEConnect. See bsc#1101470.
+%if 0%{?sle_version} < 120200
 Recommends:     openssl
+%else
+Recommends:     openssl(cli)
+%endif
 Recommends:     sed
 Recommends:     curl
 Requires:       zypper(auto-agree-with-product-licenses)


### PR DESCRIPTION
Due to the way openssl was recommended, one could not install openssl
1.0 from the Legacy module without uninstalling SUSEConnect. To bypass
this, they added a resolvable that represents the openssl cli (which is
what SUSEConnect needs).
This resolvable has only been released on SLES 12 SP2+SP3 and SLES 15,
so we need to fall back to the previous recommend on SLES 12 SP0 + SP1.
See: https://bugzilla.suse.com/show_bug.cgi?id=1101470

This change was initially submitted to our Build Service project (see
https://build.opensuse.org/request/show/637066) but it did not account
for the SLE 12 SP0 and SP1 case.