### PR TITLE
Show not available extensions/modules in list extensions command

### DIFF
--- a/lib/suse/connect/status.rb
+++ b/lib/suse/connect/status.rb
@@ -64,9 +64,8 @@ module SUSE
       def extract_extensions(product)
         extensions = []
         product.extensions.each do |extension|
-          # Skip products which have `available: false` set by SMT.
-          next if extension.available == false
           extensions << {
+            available: extension.available.nil? ? true : extension.available,
             activation_code: build_product_activation_code(extension),
             name: extension.friendly_name,
             free: extension.free,

--- a/lib/suse/connect/templates/extension_item.text.erb
+++ b/lib/suse/connect/templates/extension_item.text.erb
@@ -1,11 +1,8 @@
 <%= indent(level) %>\e[1m<%= extension[:name] %>\e[0m<%
-  if extension[:installed]
-    %> \e[32m(Installed)\e[0m
-<%= indent(level) %>Deactivate with: <%= @binary %> \e[31m-d\e[0m -p <%= extension[:activation_code] %><%
-  else %><%
-    if extension[:activated]
-      %> \e[33m(Activated)\e[0m<%
-    end %>
-<%= indent(level) %>Activate with: <%= @binary %><%= '   ' if any_installed %> -p <%= extension[:activation_code] %><% unless extension[:free] %> -r \e[32m\e[1mADDITIONAL REGCODE\e[0m<%
-    end %><%
-  end %>
+unless extension[:available] %> \e[31m(Not available)\e[0m<% end -%>
+<% if extension[:activated] %> \e[33m(Activated)\e[0m<% end -%>
+<% if extension[:activated] %>
+<%= indent(level) %>Deactivate with: <%= @binary %> \e[31m-d\e[0m -p <%= extension[:activation_code] %>
+<% else %>
+<%= indent(level) %>Activate with: <%= @binary %> -p <%= extension[:activation_code] %><% unless extension[:free] %> -r \e[32m\e[1mADDITIONAL REGCODE\e[0m <% end %>
+<% end -%>

--- a/lib/suse/connect/templates/extensions_list.text.erb
+++ b/lib/suse/connect/templates/extensions_list.text.erb
@@ -4,6 +4,12 @@
 <%  available_system_extensions.sort_by { |ext| ext[:name] }.each do |extension| -%>
 <%=   render 'extension.text', { extension: extension, any_installed: any_installed, level: 1 } -%>
 <% end -%>
+
+\e[1mREMARKS\e[0m
+
+\e[31m(Not available)\e[0m The module/extension is \e[1mnot\e[0m mirrored or enabled on your RMT/SMT
+\e[33m(Activated)\e[0m     The module/extension is activated on your system
+
 \e[1mMORE INFORMATION\e[0m
 
 You can find more information about available modules here:

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -142,12 +142,12 @@ describe SUSE::Connect::Status do
       expect(&subject).to output(%r{sle-live-patching/12/ppc64le}).to_stdout
       expect(&subject).to output(/^        \e\[1mSUSE Linux Enterprise Unreal Module 12 ppc64le\e\[0m$/).to_stdout
       expect(&subject).to output(%r{sle-unreal/12/ppc64le}).to_stdout
-      expect(&subject).not_to output(/Unavailable/).to_stdout
+      expect(&subject).not_to output(/Unavailable Module 12 ppc64le \e\[31m(Not available)\e\[0m$/).to_stdout
     end
 
     context 'with installed module' do
       before { allow(Zypper).to receive(:installed_products).and_return [Zypper::Product.new(name: 'sle-sdk', version: '12', arch: 'ppc64le')] }
-      it { expect(&subject).to output(/^    \e\[1mSUSE Linux Enterprise Software Development Kit 12 ppc64le\e\[0m \e\[32m\(Installed\)\e\[0m$/).to_stdout }
+      it { expect(&subject).to output(/^    \e\[1mSUSE Linux Enterprise Software Development Kit 12 ppc64le\e\[0m$/).to_stdout }
     end
 
     context 'with activated module' do
@@ -177,6 +177,7 @@ describe SUSE::Connect::Status do
       allow(Zypper).to receive(:installed_products).and_return []
       allow(Zypper).to receive(:base_product).and_return Zypper::Product.new(name: 'SLES', version: '12', arch: 'x86_64')
       allow(client_double).to receive(:show_product).with(Zypper.base_product).and_return(Remote::Product.new(dummy_product_data))
+
       expect(subject.available_system_extensions).to match_array([
         {
           activation_code: 'sle-sdk/12/ppc64le',
@@ -184,6 +185,7 @@ describe SUSE::Connect::Status do
           free: true,
           installed: false,
           activated: false,
+          available: true,
           extensions: []
         },
         {
@@ -192,14 +194,25 @@ describe SUSE::Connect::Status do
           free: false,
           installed: false,
           activated: false,
+          available: true,
           extensions: [{
             activation_code: 'sle-unreal/12/ppc64le',
             name: 'SUSE Linux Enterprise Unreal Module 12 ppc64le',
             free: true,
             installed: false,
             activated: false,
+            available: true,
             extensions: []
           }]
+        },
+        {
+          available: false,
+          activation_code: 'Unavailable/12/ppc64le',
+          name: 'Unavailable Module 12 ppc64le',
+          free: true,
+          installed: false,
+          activated: false,
+          extensions: []
         }
       ])
     end


### PR DESCRIPTION
This commit adds also not available modules to the `list-extensions` output. Additionally I removed the `(Installed)` label since it does not provide any real value except that the release package was installed.