### PR TITLE
Show non-enabled extensions with a remark about availability

### DIFF
--- a/lib/suse/connect/templates/extensions_list.text.erb
+++ b/lib/suse/connect/templates/extensions_list.text.erb
@@ -7,11 +7,10 @@
 
 \e[1mREMARKS\e[0m
 
-\e[31m(Not available)\e[0m The module/extension is \e[1mnot\e[0m mirrored or enabled on your RMT/SMT
+\e[31m(Not available)\e[0m The module/extension is \e[1mnot\e[0m enabled on your RMT/SMT
 \e[33m(Activated)\e[0m     The module/extension is activated on your system
 
 \e[1mMORE INFORMATION\e[0m
 
 You can find more information about available modules here:
 https://www.suse.com/products/server/features/modules.html
-

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec  7 10:43:29 UTC 2018 - fschueller@suse.com
+
+- Update to 0.3.16
+  - Show non-enabled extensions with a remark about availability
+
+-------------------------------------------------------------------
 Fri Nov 16 14:04:19 UTC 2018 - fschueller@suse.com
 
 - Update to 0.3.15

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.15
+Version:        0.3.16
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
We do not yet have a feature that enables querying of the mirroring 
status, so we can only give information about enablement on RMT/SMT.