### PR TITLE
Lock bundler to 1.17.3

### DIFF
--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -17,7 +17,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler -v 1.17.3 --no-document
+    gem install bundler --version '~> 1.17' --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -17,7 +17,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler --no-document
+    gem install bundler -v 1.17.3 --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -20,7 +20,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler --no-document
+    gem install bundler -v 1.17.3 --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -20,7 +20,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler -v 1.17.3 --no-document
+    gem install bundler --version '~> 1.17' --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -18,7 +18,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler -v 1.17.3 --no-document
+    gem install bundler --version '~> 1.17' --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -18,7 +18,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler --no-document
+    gem install bundler -v 1.17.3 --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -18,7 +18,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler -v 1.17.3 --no-document
+    gem install bundler --version '~> 1.17' --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -18,7 +18,7 @@ RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regco
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler --no-document
+    gem install bundler -v 1.17.3 --no-document
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect


### PR DESCRIPTION
This is the last version that requires `ruby >= 1.8.7`. Pulling 
`bundler` without version requirement installs `bundler >= 2.0`, which 
requires `ruby >= 2.3.0`, uninstallable with system ruby on SLES 12 SPx. 

CI seems to be failing currently because of that error.