### PR TITLE
Remove base product service based on name instead of URL

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -58,7 +58,7 @@ module SUSE
           deregister_product(@config.product)
         else
           # obtain base product service information
-          base_product_service = activate_product(Zypper.base_product)
+          base_product_service = upgrade_product(Zypper.base_product)
 
           tree = show_product(Zypper.base_product)
           installed = Zypper.installed_products.map(&:identifier)

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -57,6 +57,9 @@ module SUSE
         if @config.product
           deregister_product(@config.product)
         else
+          # obtain base product service information
+          base_product_service = activate_product(Zypper.base_product)
+
           tree = show_product(Zypper.base_product)
           installed = Zypper.installed_products.map(&:identifier)
           dependencies = flatten_tree(tree).select { |e| installed.include? e[:identifier] }
@@ -65,6 +68,8 @@ module SUSE
             deregister_product(product)
           end
           @api.deregister(system_auth)
+
+          remove_or_refresh_service(base_product_service)
           log.info "\nCleaning up ..."
           System.cleanup!
           log.info "Successfully deregistered system\n".log_green.bold

--- a/lib/suse/connect/migration.rb
+++ b/lib/suse/connect/migration.rb
@@ -75,18 +75,14 @@ module SUSE
         # @param [String] service_name the name of the service to add
         def add_service(service_url, service_name)
           # don't try to add the service if the plugin with the same name exists (bsc#1128969)
-          unless File.exist?("/usr/lib/zypp/plugins/services/#{service_name}")
-            SUSE::Connect::Zypper.add_service(service_url, service_name)
-          end
+          SUSE::Connect::Zypper.add_service(service_url, service_name) unless File.exist?("/usr/lib/zypp/plugins/services/#{service_name}")
         end
 
         # Forwards the service names which should be removed with zypper
         # @param [String] service_name the name of the service to remove
         def remove_service(service_name)
           # don't try to remove the service if the plugin with the same name exists (bsc#1128969)
-          unless File.exist?("/usr/lib/zypp/plugins/services/#{service_name}")
-            SUSE::Connect::Zypper.remove_service(service_name)
-          end
+          SUSE::Connect::Zypper.remove_service(service_name) unless File.exist?("/usr/lib/zypp/plugins/services/#{service_name}")
         end
 
         # Finds the solvable products available on the system

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.17'
+    VERSION = '0.3.18'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 29 13:15:05 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+
+- Update to 0.3.18
+- Fix base product service removal during de-registration in public clouds (bsc#1136752)
+
+-------------------------------------------------------------------
 Tue Apr  2 12:33:41 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Update to 0.3.17

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.17
+Version:        0.3.18
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -574,6 +574,7 @@ describe SUSE::Connect::Client do
   describe '#deregister!' do
     let(:stubbed_response) { OpenStruct.new(code: 204, body: nil, success: true) }
     let(:product_list) { [product] }
+    let(:base_product_service) { SUSE::Connect::Remote::Service.new({ 'name' => 'dummy_base_product', 'product' => {} }) }
 
     subject { client_instance.deregister! }
 
@@ -589,6 +590,8 @@ describe SUSE::Connect::Client do
         allow(Zypper).to receive(:base_product).and_return(product)
         allow(Zypper).to receive(:installed_products).and_return(product_list)
         allow(client_instance).to receive(:show_product).and_return(product)
+        allow(client_instance).to receive(:activate_product).and_return base_product_service
+        allow(System).to receive(:remove_service).with(base_product_service)
       end
 
       it 'calls underlying api and removes credentials file' do
@@ -606,6 +609,7 @@ describe SUSE::Connect::Client do
 
         it 'prints confirmation message' do
           expect(string_logger).to receive(:info).with("\e[1mDeregistering system from SUSE Customer Center\e[22m")
+          expect(string_logger).to receive(:info).with('-> Removing service from system ...')
           expect(string_logger).to receive(:info).with("\nCleaning up ...")
           expect(string_logger).to receive(:info).with("\e[1m\e[32mSuccessfully deregistered system\n\e[0m\e[22m")
           subject
@@ -632,6 +636,7 @@ describe SUSE::Connect::Client do
           allow(Zypper).to receive :remove_release_package
           allow(Zypper).to receive(:installed_products).and_return installed_products
           allow(client_instance).to receive(:show_product).and_return product
+          allow(client_instance).to receive(:activate_product).and_return base_product_service
         end
 
         it 'removes all extensions if no product was specified' do
@@ -643,6 +648,7 @@ describe SUSE::Connect::Client do
 
         it 'removes SCC service and release package for extension' do
           expect(client_instance).not_to receive(:deactivate_product).with(product)
+          expect(System).to receive(:remove_service).with(base_product_service)
           [extension_4_2, extension_4, recommended_2_2, recommended_2].each do |ext|
             expect(client_instance).to receive(:deactivate_product).with(ext).and_return product_service
             expect(System).to receive(:remove_service).with(product_service)
@@ -658,7 +664,7 @@ describe SUSE::Connect::Client do
           expect(string_logger).to receive(:info).with("\nDeactivating 4-Extension 1337 x86_64 ...")
           expect(string_logger).to receive(:info).with("\nDeactivating 2-2-Recommended 83 x86_64 ...")
           expect(string_logger).to receive(:info).with("\nDeactivating 2-Recommended 15 x86_64 ...")
-          expect(string_logger).to receive(:info).with('-> Removing service from system ...').exactly(4).times
+          expect(string_logger).to receive(:info).with('-> Removing service from system ...').exactly(5).times
           expect(string_logger).to receive(:info).with('-> Removing release package ...').exactly(4).times
           expect(string_logger).to receive(:info).with("\nCleaning up ...")
           expect(string_logger).to receive(:info).with("\e[1m\e[32mSuccessfully deregistered system\n\e[0m\e[22m")

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -590,7 +590,7 @@ describe SUSE::Connect::Client do
         allow(Zypper).to receive(:base_product).and_return(product)
         allow(Zypper).to receive(:installed_products).and_return(product_list)
         allow(client_instance).to receive(:show_product).and_return(product)
-        allow(client_instance).to receive(:activate_product).and_return base_product_service
+        allow(client_instance).to receive(:upgrade_product).and_return base_product_service
         allow(System).to receive(:remove_service).with(base_product_service)
       end
 
@@ -636,7 +636,7 @@ describe SUSE::Connect::Client do
           allow(Zypper).to receive :remove_release_package
           allow(Zypper).to receive(:installed_products).and_return installed_products
           allow(client_instance).to receive(:show_product).and_return product
-          allow(client_instance).to receive(:activate_product).and_return base_product_service
+          allow(client_instance).to receive(:upgrade_product).and_return base_product_service
         end
 
         it 'removes all extensions if no product was specified' do


### PR DESCRIPTION
Service removal works differently during de-registration based on product type:

* extensions are de-registered using single product deactivation endpoint, which returns service name in response -- these services are removed by name;
* base product is de-registerd using system de-registration endpoint, which returns an empty response -- the services are then cleaned up based on them having the same URLs as registration server URL.

PubCloud RMT's serve `plugin:/susecloud` URLs (which doesn't match registration server URL in `/etc/SUSEConnect`) -- because of that the services aren't removed.

With this change base product will be removed based on service name (while still applying the old logic after that).