### PR TITLE
Add curl to app Docker containers

### DIFF
--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -10,7 +10,7 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-stan
     zypper --non-interactive --gpg-auto-import-keys ref &&\
     zypper --non-interactive up zypper &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
-      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo && \
+      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-standard SLE-12-update-standard SLE-12-ltss
 
 RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -13,7 +13,7 @@ RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
     zypper --non-interactive --gpg-auto-import-keys ref &&\
     zypper --non-interactive up zypper &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
-      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo && \
+      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP1-standard SLE-12-SP1-updates sle12sp1sdk sle12sp1sdk-updates
 
 RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -11,7 +11,7 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
     zypper --non-interactive --gpg-auto-import-keys ref &&\
     zypper --non-interactive up zypper &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
-      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo && \
+      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP2-standard SLE-12-SP2-updates sle12sp2sdk sle12sp2sdk-updates
 
 RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -11,7 +11,7 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
     zypper --non-interactive --gpg-auto-import-keys ref &&\
     zypper --non-interactive up zypper &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
-      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo && \
+      vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP3-standard SLE-12-SP3-updates sle12sp3sdk sle12sp3sdk-updates
 
 RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode

--- a/Dockerfile.15sp0
+++ b/Dockerfile.15sp0
@@ -10,7 +10,7 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/ sles-pool &
     zypper --non-interactive --gpg-auto-import-keys ref &&\
     zypper --non-interactive up &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
-      vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk 
+      vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk curl
 
 RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
 RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc


### PR DESCRIPTION
`rmt-client-setup` uses curl rather than wget, so it needs to be present to register the container to RMT.