### PR TITLE
Fix failing on registered system without arguments

### DIFF
--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -75,7 +75,7 @@ Please consult the corresponding [OBS page](https://build.opensuse.org/package/s
 
 ## Step 6. Committing the package
 
-To submit the package:
+After the PR is approved, to submit the package:
 ```bash
 cd package
 osc status

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -42,7 +42,7 @@ module SUSE
           elsif @config.token && @config.instance_data_file
             log.error 'Please use either --regcode or --instance-data'
             exit(1)
-          elsif @config.url_default? && !@config.token && !status.activated_base_product?
+          elsif @config.url_default? && !@config.token && !@config.product
             puts @opts
             exit(1)
           else

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.18'
+    VERSION = '0.3.19'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  7 10:15:21 UTC 2019 - Giovanni Filippetti <giovanni.filippetti@suse.com>
+
+- Update to 0.3.19
+  - Fix failing on registered system without arguments (bsc#1144020)
+
+-------------------------------------------------------------------
 Wed May 29 13:15:05 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Update to 0.3.18

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.18
+Version:        0.3.19
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -119,7 +119,6 @@ describe SUSE::Connect::Cli do
 
       context 'when the system has no activated base product' do
         it 'shows a properly rendered help page' do
-          expect_any_instance_of(Status).to receive(:activated_base_product?).and_return(false)
           expect_any_instance_of(Client).not_to receive(:register!)
           expect_any_instance_of(described_class).to receive(:puts) do |option_parser|
             expect(option_parser.instance_variable_get(:@opts).to_s.split("\n").map(&:length)).to all be <= 80

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -138,6 +138,12 @@ describe SUSE::Connect::Cli do
           expect_any_instance_of(SUSE::Connect::Config).to receive(:write!)
           cli.execute!
         end
+
+        it 'registers the system if using a configured proxy' do
+          allow_any_instance_of(SUSE::Connect::Config).to receive(:url_default?).and_return(false)
+          expect_any_instance_of(Client).to receive(:register!)
+          cli.execute!
+        end
       end
 
       it 'requires either --regcode or --url (regcode-less SMT registration) but respects config attributes' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/vCyggMVc)

The solution was to remove the `status` check, and also to introduce a check for the `product` param that was not being verified and is needed for products that don't require a regcode.