### PR TITLE
fix packagehub activation

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.20'
+    VERSION = '0.3.21'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 26 09:53:36 UTC 2019 - Thomas Schmidt <tschmidt@suse.com>
+
+- Update to 0.3.21
+  Fix error on first activation of packagehub extension (bsc#1124318)
+
+-------------------------------------------------------------------
 Wed Aug 8 16:02:30 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Update to 0.3.20

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.20
+Version:        0.3.21
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -406,13 +406,21 @@ describe SUSE::Connect::Zypper do
 
   describe '.install_release_package' do
     context 'when the release package is not yet installed' do
+      let(:status_106) { double('Process Status', exitstatus: Zypper::ExitCode::Info::REPOS_SKIPPED) }
       it 'calls zypper install' do
-        expect(Open3).to receive(:capture3).with(shared_env_hash, 'rpm -q opensuse-release')
-                           .and_return(['', '', 1])
+        expect(Open3).to receive(:capture3).with(shared_env_hash, 'rpm -q opensuse-release').and_return(['', '', 1])
 
         expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product opensuse') # rubocop:disable LineLength
                                            .and_return(['', '', status])
         subject.install_release_package('opensuse')
+      end
+
+      it 'accepts initial repo refresh issue for PackageHub' do
+        expect(Open3).to receive(:capture3).with(shared_env_hash, 'rpm -q PackageHub-release').and_return(['', '', 1])
+
+        expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product PackageHub') # rubocop:disable LineLength
+                                           .and_return(['', 'Error building the cache', status_106])
+        subject.install_release_package('PackageHub')
       end
     end
 


### PR DESCRIPTION
on initial refresh of packagehub repositories, SUSEConnect gets an error 106 from zypper because of untrusted repo signing key. this patch works around this by allowing the initial refresh to fail for this product.