### PR TITLE
add 15sp2 products to integration environment

### DIFF
--- a/features/support/environments.yml
+++ b/features/support/environments.yml
@@ -3,8 +3,12 @@ SLE_15:
   beta: true
   online_migration_targets:
   - "Basesystem-Module"
+  - "Basesystem-Module"
+  - "Python2-Module"
   - "Python2-Module"
   - "SLES15-SP1"
+  - "SLES15-SP2"
+  - "Server-Applications-Module"
   - "Server-Applications-Module"
   next_version: SLES15-SP1
   base_product:


### PR DESCRIPTION
This is the naive way to fix the integration tests, by testing both sp2 and sp1 as migrations from GA. It seems to be how this was addressed the last time these tests failed.

Is this correct though?  I could also add a 15SP1-> 15SP2 test section, and a 12SP4->SP5 test.