### PR TITLE
YaST package search

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.25'
+    VERSION = '0.3.26'
   end
 end

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -225,6 +225,19 @@ module SUSE
           config = SUSE::Connect::Config.new.merge!(client_params)
           Status.new(config)
         end
+
+        # Provides access to the package search functionality
+        #
+        # @param query [String] package to search
+        # @param product [SUSE::Connect::Zypper::Product] product to base search on
+        # @param config_params [<Hash>] overwrites from the config file
+        #
+        # @return [Array< <Hash>>] Returns all matched packages or an empty array if no matches where found
+        #
+        # @see SUSE::Connect::PackageSearch.search
+        def search_package(query, product: Zypper.base_product, config_params: {})
+          SUSE::Connect::PackageSearch.search(query, product: product, config_params: config_params)
+        end
       end
     end
   end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 22 09:05:17 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Update to 0.3.26
+  - Extend the YaST API in order to access to the package search
+    functionality (jsc#SLE-9109)
+
+-------------------------------------------------------------------
 Thu Jan  2 12:57:23 UTC 2020 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Update to 0.3.25

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.25
+Version:        0.3.26
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -423,8 +423,8 @@ describe SUSE::Connect::YaST do
   end
 
   describe '.search_package' do
-    let(:base_product) { SUSE::Connect::Zypper::Product.new(name: "SLES", arch: "x86_64", version: "15.2") }
-    let(:results) { [{ name: "foobar"}] }
+    let(:base_product) { SUSE::Connect::Zypper::Product.new(name: 'SLES', arch: 'x86_64', version: '15.2') }
+    let(:results) { [{ name: 'foobar' }] }
 
     before do
       allow(SUSE::Connect::Zypper).to receive(:base_product).and_return(base_product)
@@ -438,7 +438,7 @@ describe SUSE::Connect::YaST do
     end
 
     context 'when a product is given' do
-      let(:product) { SUSE::Connect::Zypper::Product.new(name: "SLED", arch: "x86_64", version: "15.2") }
+      let(:product) { SUSE::Connect::Zypper::Product.new(name: 'SLED', arch: 'x86_64', version: '15.2') }
 
       it 'searches for a package in the given product' do
         expect(SUSE::Connect::PackageSearch).to receive(:search)

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -421,4 +421,34 @@ describe SUSE::Connect::YaST do
       expect(subject.list_installer_updates(product, client_params)).to eq []
     end
   end
+
+  describe '.search_package' do
+    let(:base_product) { SUSE::Connect::Zypper::Product.new(name: "SLES", arch: "x86_64", version: "15.2") }
+    let(:results) { [{ name: "foobar"}] }
+
+    before do
+      allow(SUSE::Connect::Zypper).to receive(:base_product).and_return(base_product)
+      allow(SUSE::Connect::PackageSearch).to receive(:search).and_return(results)
+    end
+
+    it 'searches for a package in the base product' do
+      expect(SUSE::Connect::PackageSearch).to receive(:search)
+        .with('foobar', product: base_product, config_params: {})
+      subject.search_package('foobar')
+    end
+
+    context 'when a product is given' do
+      let(:product) { SUSE::Connect::Zypper::Product.new(name: "SLED", arch: "x86_64", version: "15.2") }
+
+      it 'searches for a package in the given product' do
+        expect(SUSE::Connect::PackageSearch).to receive(:search)
+          .with('foobar', product: product, config_params: {})
+        subject.search_package('foobar', product: product)
+      end
+    end
+
+    it 'returns an array with the results' do
+      expect(subject.search_package('foobar')).to eq(results)
+    end
+  end
 end


### PR DESCRIPTION
This PR extends the YaST API to access to the package search functionality. It is needed in order to implement the [online search feature](https://jira.suse.com/browse/SLE-9109). 