### PR TITLE
Do not fail the call to de-install release package when it is not found.

### DIFF
--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -166,7 +166,8 @@ module SUSE
         end
 
         def remove_release_package(identifier)
-          call("--no-refresh --non-interactive remove -t product #{identifier}") if identifier
+          valid_error_codes = [Zypper::ExitCode::OK, Zypper::ExitCode::Info::CAP_NOT_FOUND]
+          call("--no-refresh --non-interactive remove -t product #{identifier}", true, valid_error_codes) if identifier
         end
 
         # rubocop:disable AccessorMethodName

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 30 13:39:05 UTC 2020 - Thomas Schmidt <tschmidt@suse.com>
+
+- Don't fail de-activation when '-release' package already got removed
+
+-------------------------------------------------------------------
 Thu Jan  2 12:57:23 UTC 2020 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Update to 0.3.25

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -436,10 +436,20 @@ describe SUSE::Connect::Zypper do
   end
 
   describe '.remove_release_package' do
-    it 'calls the command' do
-      expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper --no-refresh --non-interactive remove -t product opensuse')
-                                         .and_return(['', '', status])
-      subject.remove_release_package('opensuse')
+    context 'when the release package is installed' do
+      it 'calls the command' do
+        expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper --no-refresh --non-interactive remove -t product opensuse')
+                                           .and_return(['', '', status])
+        subject.remove_release_package('opensuse')
+      end
+    end
+    context 'when the release package got removed manually before' do
+      let(:status_104) { double('Process Status', exitstatus: Zypper::ExitCode::Info::CAP_NOT_FOUND) }
+      it "doesn't throw an error" do
+        expect(Open3).to receive(:capture3).with(shared_env_hash, 'zypper --no-refresh --non-interactive remove -t product opensuse')
+                                           .and_return(['', 'No provider of \'opensuse\' found.', status_104])
+        subject.remove_release_package('opensuse')
+      end
     end
   end
 


### PR DESCRIPTION
There is no need to fail when the release package was already removed 
by the user, or was not installed because the product was missing it. 
See https://trello.com/c/pQ1CQHzF/3906-cnt-make-product-de-installation-more-failsafe