### PR TITLE
Write Config Even During Failure Conditions

### DIFF
--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -49,8 +49,6 @@ module SUSE
             Client.new(@config).register!
           end
         end
-
-        @config.write! if @config.write_config
       rescue Errno::ECONNREFUSED
         log.fatal "Error: Connection refused by server #{@config.url}"
         exit 64
@@ -84,6 +82,8 @@ module SUSE
       rescue BaseProductDeactivationError
         log.fatal 'Can not deregister base product. Use SUSEConnect -d to deactivate the whole system.'
         exit 70
+      ensure
+        @config.write! if @config.write_config
       end
 
       private

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -104,6 +104,7 @@ module SUSE
         params.push(@config.namespace) if @config.namespace
 
         response = @api.announce_system(*params)
+
         [response.body['login'], response.body['password']]
       end
 

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.26'
+    VERSION = '0.3.27'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,5 +1,14 @@
--------------------------------------------------------------------
+------------------------------------------------------------------
+Mon Aug 31 14:10:15 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 
+- Update to 0.3.27
+- SUSEConnect now ensures that it writes its configuration when it
+  encounters errors. This helps in the situation where SUSEConnect
+  announces itself, but fails during a later step. Without the saved
+  configuration, a system could have credentials, but be unsure which
+  registration proxy they're valid for.
+
+-------------------------------------------------------------------
 Wed Aug 26 14:37:17 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update to 0.3.26


### PR DESCRIPTION
We noticed a problem in RMT that came from a failure logic in
SUSEConnect.

* A server is registered against RMT with SUSEConnect, but that product
  isn't mirrored yet in RMT.
* As the Connect API announce endpoint does not verify that a product is
  mirrored, RMT has no idea that a subsequent call will try to activate
  an unmirrored product.
* The server is announced to RMT, so RMT gave it credentials which are
  saved on the server.
* During the activation phase, RMT tells the server it can't activate,
  so the registration process in SUSEConenct errors and the config isn't
  written.

The problem is that SUSEConnect already got the credentials from the
RMT server, but because it errored, it didn't save /etc/SUSEConnect to
know where those credentials are valid. Instead, we should save
/etc/SUSEConnect, as the system is valid in RMT, it's activation just
isn't and can be fixed without a deregistration.