### PR TITLE
Make the OEM API bash client an actual bash file

### DIFF
--- a/doc/OEM-API-Bash-Client.sh
+++ b/doc/OEM-API-Bash-Client.sh
@@ -1,4 +1,3 @@
-```bash
 #!/bin/bash
 # Author: https://github.com/wstephenson
 # This script is to demonstrate the use of the SCC OEM partner order API
@@ -45,4 +44,3 @@ fi
 
 # Make the api call
 curl "$host$path" -H "$h_content_type" -H "$h_date" -H "$h_content_md5" -H "$h_authorization" $data_opt
-```

--- a/doc/OEM-Partner-API.md
+++ b/doc/OEM-Partner-API.md
@@ -38,7 +38,7 @@ Second and third parts are connected with a colon.
 
 Implementations of HMAC are linked from the footer of https://en.wikipedia.org/wiki/Hash-based_message_authentication_code
 
-We also have reference [implementation](OEM-API-Bash-Client.md) in Bash
+We also have reference [implementation](OEM-API-Bash-Client.sh) in Bash
 
 ## List of Partner Orders
 


### PR DESCRIPTION
That way it's easier to link to line numbers. It's a pure bash file, so there's no real need for it to be bash embedded in markdown.