### PR TITLE
Support different format of .curlrc

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.27'
+    VERSION = '0.3.28'
   end
 end

--- a/lib/suse/toolkit/curlrc_dotfile.rb
+++ b/lib/suse/toolkit/curlrc_dotfile.rb
@@ -1,11 +1,13 @@
 require 'etc'
-# implementing interface to ~/.curlrc which can hold proxy details
+
+# Yast is not adding proxy credentials to the 'http_proxy' env variable, but writing
+# them to ~/.curlrc. This class is parsing the credentials from there to be used in connection.rb
 class SUSE::Toolkit::CurlrcDotfile
   CURLRC_LOCATION = '.curlrc'
 
-  # Yast is setting up the credentials in .curlrc in '--proxy-user "user:pwd"' style,
+  # Yast is setting up the credentials in ~/.curlrc in '--proxy-user "user:pwd"' style,
   # but https://www.suse.com/support/kb/doc/?id=000017441 uses 'proxy-user = "john:n0v3ll"'.
-  # We should support both formats in SUSEConnect
+  # SUSEConnect should be capable of reading both formats
   CURLRC_CREDENTIALS_REGEXP = /-*proxy-user[ =]*"(.+):(.+)"/
 
   def initialize

--- a/lib/suse/toolkit/curlrc_dotfile.rb
+++ b/lib/suse/toolkit/curlrc_dotfile.rb
@@ -3,6 +3,11 @@ require 'etc'
 class SUSE::Toolkit::CurlrcDotfile
   CURLRC_LOCATION = '.curlrc'
 
+  # Yast is setting up the credentials in .curlrc in '--proxy-user "user:pwd"' style,
+  # but https://www.suse.com/support/kb/doc/?id=000017441 uses 'proxy-user = "john:n0v3ll"'.
+  # We should support both formats in SUSEConnect
+  CURLRC_CREDENTIALS_REGEXP = /-*proxy-user[ =]*"(.+):(.+)"/
+
   def initialize
     @file_location = File.join(Etc.getpwuid.dir, CURLRC_LOCATION)
   end
@@ -12,11 +17,11 @@ class SUSE::Toolkit::CurlrcDotfile
   end
 
   def username
-    line_with_credentials.match(/--proxy-user\s?"(.*):/)[1] rescue nil
+    line_with_credentials.match(CURLRC_CREDENTIALS_REGEXP)[1] rescue nil
   end
 
   def password
-    line_with_credentials.match(/--proxy-user\s?".*:(.*)"/)[1] rescue nil
+    line_with_credentials.match(CURLRC_CREDENTIALS_REGEXP)[2] rescue nil
   end
 
   private

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,3 +1,9 @@
+-------------------------------------------------------------------
+Mon Sep 28 17:36:08 UTC 2020 - Thomas Schmidt <tschmidt@suse.com>
+
+- Recognize more formats when parsing .curlrc for proxy credentials (bsc#1155027)
+- Add rpmlintrc to filter false-positive warning about patch not applied
+
 ------------------------------------------------------------------
 Mon Aug 31 14:10:15 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.27
+Version:        0.3.28
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
Yast is not adding proxy credentials to the 'http_proxy' env variable, but writing them to ~/.curlrc. 
Our used library `Net::HTTP` is not parsing that file, so we need to parse it in SUSEConnect to 
set proxy credentials for the connection. 

Until now SUSEConnect was only supporting the format of .curlrc that Yast writes: `--proxy-user "meuser1$:mepassord2%"`.
In https://www.suse.com/support/kb/doc/?id=000017441, SUSE asks customers to use a different format: `proxy-user = "meuser1$:mepassord2%"`

With this patch, SUSEConnect can read both formats from .curlrc