### PR TITLE
replace env ruby with native path

### DIFF
--- a/package/SUSEConnect-rpmlintrc
+++ b/package/SUSEConnect-rpmlintrc
@@ -1,3 +1,2 @@
 # this patch gets applied conditionally inline the .spec file
 addFilter("SUSEConnect.src: W: patch-not-applied Patch0: switch_server_cert_location_to_etc.patch")
-addFilter("SUSEConnect.x86_64: E: env-script-interpreter")

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov 17 09:36:24 UTC 2020 - Tamara Schmitz <tamara.schmitz@suse.com>
+
+- replace env ruby path with native ruby path during build phase
+
+-------------------------------------------------------------------
 Mon Sep 28 17:36:08 UTC 2020 - Thomas Schmidt <tschmidt@suse.com>
 
 - Recognize more formats when parsing .curlrc for proxy credentials (bsc#1155027)

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -128,6 +128,9 @@ touch %{buildroot}%_sysconfdir/SUSEConnect
 mkdir -p %{buildroot}%_sysconfdir/zypp/credentials.d/
 touch %{buildroot}%_sysconfdir/zypp/credentials.d/SCCcredentials
 
+# replace /usr/bin/env with native ruby path
+sed -i "1s/.*/#\!\/usr\/bin\/ruby\.%{ruby_version}/" %{buildroot}%{_sbindir}/%{name}
+
 %post
 if [ -s /etc/zypp/credentials.d/NCCcredentials ] && [ ! -e /etc/zypp/credentials.d/SCCcredentials ]; then
     echo "Imported NCC system credentials to /etc/zypp/credentials.d/SCCcredentials"

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.28
+Version:        0.3.29
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
builds in home branch on OBS succeeded.

Addresses a packaging guideline.