### PR TITLE
Ruby ver replace in spec

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.28'
+    VERSION = '0.3.29'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Tue Nov 17 09:36:24 UTC 2020 - Tamara Schmitz <tamara.schmitz@suse.com>
 
+- Update to 0.3.29
 - replace env ruby path with native ruby path during build phase
 
 -------------------------------------------------------------------

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -128,6 +128,10 @@ touch %{buildroot}%_sysconfdir/SUSEConnect
 mkdir -p %{buildroot}%_sysconfdir/zypp/credentials.d/
 touch %{buildroot}%_sysconfdir/zypp/credentials.d/SCCcredentials
 
+# replace /usr/bin/env with native ruby path
+sed -i "1s/.*/#\!\/usr\/bin\/ruby\.%{ruby_version}/" %{buildroot}%{_sbindir}/%{name}
+sed -i "1s/.*/#\!\/usr\/bin\/ruby\.%{ruby_version}/" %{buildroot}%{gem_base}/gems/%{mod_full_name}/bin/%{name}
+
 %post
 if [ -s /etc/zypp/credentials.d/NCCcredentials ] && [ ! -e /etc/zypp/credentials.d/SCCcredentials ]; then
     echo "Imported NCC system credentials to /etc/zypp/credentials.d/SCCcredentials"

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.28
+Version:        0.3.29
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
As it turns out, SUSEConnect exists twice: in /usr/sbin and in the ruby gem folder. 
In addition to that I forgot to bump the gem version in my PR.

Please squash and merge