### PR TITLE
Add the subscription name to the output of 'SUSEConnect --status'

### DIFF
--- a/lib/suse/connect/status.rb
+++ b/lib/suse/connect/status.rb
@@ -103,6 +103,7 @@ module SUSE
           unless product_status.remote_product && product_status.remote_product.free
             if product_status.related_activation
               activation = product_status.related_activation
+              status[:name] = activation.name
               status[:regcode] = activation.regcode
               status[:starts_at] = activation.starts_at ? Time.parse(activation.starts_at) : nil
               status[:expires_at] = activation.expires_at ? Time.parse(activation.expires_at) : nil

--- a/lib/suse/connect/templates/product_statuses.text.erb
+++ b/lib/suse/connect/templates/product_statuses.text.erb
@@ -10,6 +10,7 @@ Installed Products:
 
     Subscription:
     <% activation = product_status.related_activation %>
+    Name: <%= activation.name %>
     Regcode: <%= activation.regcode %>
     Starts at: <%= activation.starts_at ? Time.parse(activation.starts_at) : nil %>
     Expires at: <%= activation.expires_at ? Time.parse(activation.expires_at) : nil %>

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -3,6 +3,7 @@ Sun Jul 21 10:00:00 UTC 2021 - Natnael Getahun <ngetahun@suse.com>
 
 - Update to 0.3.31
 - Disallow registering via SUSEConnect if the system is managed by SUSE Manager.
+- Add subscription name to output of 'SUSEConnect --status'
 
 -------------------------------------------------------------------
 Sun Jun 20 13:07:06 UTC 2021 - Thomas Schmidt <tschmidt@suse.com>

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -9,6 +9,7 @@ describe SUSE::Connect::Cli do
   let(:config_file) { File.expand_path File.join(File.dirname(__FILE__), '../fixtures/SUSEConnect') }
 
   before do
+    allow_any_instance_of(SUSE::Connect::Config).to receive(:read).and_return({})
     allow(Zypper).to receive_messages(base_product: {})
     allow_any_instance_of(described_class).to receive_messages(puts: true)
     SUSE::Connect::GlobalLogger.instance.log = string_logger

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -8,6 +8,7 @@ describe SUSE::Connect::Status do
   subject { status_instance }
 
   before do
+    allow(System).to receive(:credentials?).and_return false
     allow(Client).to receive(:new).and_return(client_double)
   end
 


### PR DESCRIPTION
This is part of https://trello.com/c/GsdqHEMe/4276-rdq-include-activated-subscription-names-in-supportconfig

SUSE/happy-customer#5791 will add the subscription name to the API output of SCC. 