### PR TITLE
Show always subscription information if available

### DIFF
--- a/lib/suse/connect/status.rb
+++ b/lib/suse/connect/status.rb
@@ -91,7 +91,6 @@ module SUSE
         template.result(binding)
       end
 
-      # rubocop:disable MethodLength
       def json_product_status
         statuses = product_statuses.map do |product_status|
           status = {}
@@ -100,16 +99,14 @@ module SUSE
           status[:arch] = product_status.installed_product.arch
           status[:status] = product_status.registration_status
 
-          unless product_status.remote_product && product_status.remote_product.free
-            if product_status.related_activation
-              activation = product_status.related_activation
-              status[:name] = activation.name
-              status[:regcode] = activation.regcode
-              status[:starts_at] = activation.starts_at ? Time.parse(activation.starts_at) : nil
-              status[:expires_at] = activation.expires_at ? Time.parse(activation.expires_at) : nil
-              status[:subscription_status] = activation.status
-              status[:type] = activation.type
-            end
+          if product_status.has_subscription_associated?
+            activation = product_status.related_activation
+            status[:name] = activation.name
+            status[:regcode] = activation.regcode
+            status[:starts_at] = activation.starts_at ? Time.parse(activation.starts_at) : nil
+            status[:expires_at] = activation.expires_at ? Time.parse(activation.expires_at) : nil
+            status[:subscription_status] = activation.status
+            status[:type] = activation.type
           end
           status
         end

--- a/lib/suse/connect/templates/product_statuses.text.erb
+++ b/lib/suse/connect/templates/product_statuses.text.erb
@@ -5,18 +5,16 @@ Installed Products:
   (<%= product_status.installed_product.identifier %>/<%= product_status.installed_product.version %>/<%= product_status.installed_product.arch %>)
 
   <%= product_status.registration_status %>
-  <% unless product_status.remote_product && product_status.remote_product.free -%>
-    <% if product_status.related_activation -%>
+  <% if product_status.has_subscription_associated? -%>
 
-    Subscription:
-    <% activation = product_status.related_activation %>
-    Name: <%= activation.name %>
-    Regcode: <%= activation.regcode %>
-    Starts at: <%= activation.starts_at ? Time.parse(activation.starts_at) : nil %>
-    Expires at: <%= activation.expires_at ? Time.parse(activation.expires_at) : nil %>
-    Status: <%= activation.status %>
-    Type: <%= activation.type %>
-    <% end %>
+  Subscription:
+  <% activation = product_status.related_activation %>
+  Name: <%= activation.name %>
+  Regcode: <%= activation.regcode %>
+  Starts at: <%= activation.starts_at ? Time.parse(activation.starts_at) : nil %>
+  Expires at: <%= activation.expires_at ? Time.parse(activation.expires_at) : nil %>
+  Status: <%= activation.status %>
+  Type: <%= activation.type %>
   <% end %>
 ------------------------------------------
 <% end %>

--- a/lib/suse/connect/zypper/product_status.rb
+++ b/lib/suse/connect/zypper/product_status.rb
@@ -30,4 +30,13 @@ class SUSE::Connect::Zypper::ProductStatus
       installed_product == remote_product
     end
   end
+
+  # There can be the case that SCC/Proxies send empty values for subscription
+  # information in an activation. Do not handle them as activation with subscription
+  # associated.
+  def has_subscription_associated?
+    return false unless related_activation
+
+    related_activation[:regcode] != nil
+  end
 end

--- a/spec/connect/status_spec.rb
+++ b/spec/connect/status_spec.rb
@@ -105,12 +105,17 @@ describe SUSE::Connect::Status do
     end
 
     context 'json format' do
+      let(:activation) do
+        SUSE::Connect::Remote::Activation.new({
+          'service' => { 'product' => {} },
+          'regcode' => 'some-regcode'
+        })
+      end
+
       it 'outputs the system status in json format' do
         status = Zypper::ProductStatus.new(Zypper::Product.new({}), subject)
         allow(status).to receive(:registration_status).and_return('test')
         allow(status).to receive(:remote_product).and_return(true)
-        expect(status).to receive_message_chain(:remote_product, :free).and_return(false)
-        activation = SUSE::Connect::Remote::Activation.new('service' => { 'product' => {} })
         allow(status).to receive(:related_activation).and_return(activation)
 
         expect(subject).to receive(:product_statuses).and_return [status]

--- a/spec/connect/zypper/product_status_spec.rb
+++ b/spec/connect/zypper/product_status_spec.rb
@@ -70,4 +70,42 @@ describe SUSE::Connect::Zypper::ProductStatus do
       expect(subject.remote_product).to eq remote_product
     end
   end
+
+  describe '#has_subscription_associated?' do
+    let(:installed_product) { Zypper::Product.new(name: :foo, version: 42, arch: :wax) }
+    let(:remote_product) { Remote::Product.new(identifier: :foo, version: 42, arch: :wax) }
+
+    subject { described_class.new(installed_product, status) }
+
+    context 'without activation' do
+      it 'returns false' do
+        expect(subject).to receive(:related_activation).and_return nil
+        expect(subject.has_subscription_associated?).to be(false)
+      end
+    end
+
+    context 'with activation' do
+      let(:activation) { double('activation') }
+      let(:regcode) { nil }
+
+      before do
+        allow(activation).to receive(:[]).with(:regcode).and_return regcode
+        allow(subject).to receive(:related_activation).twice.and_return activation
+      end
+
+      context 'without subscription associated' do
+        it 'returns false' do
+          expect(subject.has_subscription_associated?).to be(false)
+        end
+      end
+
+      context 'with subscription associated' do
+        let(:regcode) { 'some-regcode' }
+
+        it 'returns true' do
+          expect(subject.has_subscription_associated?).to be(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
card: https://trello.com/c/oE1JUPs9/2153-rdqconnect-show-associated-subscriptions-even-if-the-product-is-marked-as-free

**Changes:**

Show subscription information if available and not if the product is marked as `non free`.
This allows displaying information send by proxies which mark every product as `free`.

**How to review this PR:**

```
<sles regcode> = A normal SLES regcode from SCC
<rmt url> = A RMT running latest master (e.g. reference host / ask me in case unclear)
<rmt sles regcode> = A SLES regcode active in the organization where the RMT is configured
```


```bash
# = comment
# $ = host system
# > = container
#! = expected outcome
```
1) Test with SCC and check if activation is shown
```bash
$ docker run -v $(pwd):/connect --rm --network=host -ti connect.15sp3 /bin/bash
> cd /connect
> bin/SUSEConnect -r <sles regcode>
> bin/SUSEConnect --status-text
#! This should show the subscription information for the activated SLES.
```

2) Test with RMT with a subscription associated
```bash
$ docker run -v $(pwd):/connect --rm --network=host -ti connect.15sp3 /bin/bash
> cd /connect
> bin/SUSEConnect -r <rmt sles regcode> --url <rmt url>
> bin/SUSEConnect --status-text
#! This should show the subscription information for the activated SLES.
```

3) Test with RMT without a subscription associated
```bash
$ docker run -v $(pwd):/connect --rm --network=host -ti connect.15sp3 /bin/bash
> cd /connect
> bin/SUSEConnect --url <rmt url>
> bin/SUSEConnect --status-text
#! This should show no subscription information
```