### PR TITLE
Install systemd on aarch64

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.32'
+    VERSION = '0.3.33'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 16 14:52:50 UTC 2021 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Update to 0.3.33
+- Install systemd dependency on aarch64 systems.
+
+-------------------------------------------------------------------
 Wed Oct 27 13:26:23 UTC 2021 - Thomas Schmidt <tschmidt@suse.com>
 
 - Update to 0.3.32

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.32
+Version:        0.3.33
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}
@@ -49,6 +49,9 @@ Recommends:     curl
 Requires:       zypper(auto-agree-with-product-licenses)
 %ifarch x86_64 aarch64
 Requires:       dmidecode
+%endif
+%ifarch aarch64
+Requires:       systemd
 %endif
 Conflicts:      suseRegister, yast2-registration < 3.1.129.7
 


### PR DESCRIPTION
I recently ran into a problem with a colleague on an M1 MacBook: `SUSEConnect` didn't work in a leap 15.3 docker container.

I looked into the issue, and it seems to stem from the way we look for the hypervisor. See the following code: https://github.com/SUSE/connect/blob/ff4c739e0761b49861899fac4afc1af77960e3a5/lib/suse/connect/hwinfo/arm64.rb#L25.

The call to `systemd-detect-virt` requires the binary to be there, but it's only installed with the `systemd` package, and it's missing as a dependency.

I added this dependency for aarch64 systems in the specfile and tested it on an amazon arm system and the built package works for me.

Steps to reproduce:
1. Start a shell in an arm based linux system.
2. Start an openSUSE leap container:
   ```
   docker run --rm -it opensuse/leap:15.3
   ```
3. Install SUSEConnect:
   ```
   zypper --non-interactive in SUSEConnect
   ```
4. Register against SCC with an aarch64 regcode:
   ```
   SUSEConnect -r MY_REGCODE
   ```
5. It fails with the following
   ```
   Registering system to SUSE Customer Center

   Announcing system to https://scc.suse.com ...
   SUSEConnect error: Errno::ENOENT: No such file or directory - systemd-detect-virt
   ```