### PR TITLE
Add Keepalive command

### DIFF
--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -24,6 +24,8 @@ module SUSE
           status.print_product_statuses(:text)
         elsif @config.deregister
           Client.new(@config).deregister!
+        elsif @config.keepalive
+          Client.new(@config).keepalive!
         elsif @config.cleanup
           System.cleanup!
         elsif @config.rollback

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -136,6 +136,11 @@ module SUSE
           @options[:deregister] = true
         end
 
+        @opts.on('--keepalive',
+                 'Sends data to SCC to update the system information.') do |_opt|
+          @options[:keepalive] = true
+        end
+
         @opts.on('--instance-data  [path to file]', 'Path to the XML file holding the public key and',
                  'instance data for cloud registration with SMT.') do |opt|
           check_if_param(opt, 'Please provide the path to your instance data file')

--- a/lib/suse/connect/cli.rb
+++ b/lib/suse/connect/cli.rb
@@ -84,6 +84,9 @@ module SUSE
       rescue BaseProductDeactivationError
         log.fatal 'Can not deregister base product. Use SUSEConnect -d to deactivate the whole system.'
         exit 70
+      rescue PingNotAllowed => e
+        log.fatal "Error sending keepalive: #{e.message}"
+        exit 71
       ensure
         @config.write! if @config.write_config
       end

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -96,7 +96,7 @@ module SUSE
 
         log.info "\nSending data to SCC ..."
         @api.update_system(system_auth)
-        log.info "Successfully update system\n".log_green.bold
+        log.info "Successfully updated the system\n".log_green.bold
       end
 
       # Flatten a product tree into an array

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -4,6 +4,7 @@ require 'suse/toolkit/utilities'
 module SUSE
   module Connect
     # Client to interact with API
+    # rubocop:disable Metrics/ClassLength
     class Client
       include SUSE::Toolkit::Utilities
       include Logger
@@ -81,6 +82,25 @@ module SUSE
           System.cleanup!
           log.info "Successfully deregistered system\n".log_green.bold
         end
+      end
+
+      # Send a system update to SCC
+      #
+      # @returns: Empty body and 204 status code
+      def keepalive!
+        if File.exist?('/usr/sbin/registercloudguest')
+          raise UnsupportedOperation,
+            'Keepalive is disabled for on-demand instances.'
+        end
+        unless registered?
+          raise UnsupportedOperation,
+          'System is not registered. Use the --regcode parameter to register it.'
+        end
+
+
+        log.info "\nSending data to SCC ..."
+        @api.update_system(system_auth)
+        log.info "Successfully update system\n".log_green.bold
       end
 
       # Flatten a product tree into an array
@@ -281,5 +301,6 @@ module SUSE
         log.info "Using E-Mail: #{@config.email}" if @config.email
       end
     end
+    # rubocop:enable  Metrics/ClassLength
   end
 end

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -89,11 +89,11 @@ module SUSE
       # @returns: Empty body and 204 status code
       def keepalive!
         if File.exist?('/usr/sbin/registercloudguest')
-          raise UnsupportedOperation,
+          raise PingNotAllowed,
             'Keepalive is disabled for on-demand instances.'
         end
         unless registered?
-          raise UnsupportedOperation,
+          raise PingNotAllowed,
           'System is not registered. Use the --regcode parameter to register it.'
         end
 

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -88,10 +88,6 @@ module SUSE
       #
       # @returns: Empty body and 204 status code
       def keepalive!
-        if File.exist?('/usr/sbin/registercloudguest')
-          raise PingNotAllowed,
-            'Keepalive is disabled for on-demand instances.'
-        end
         unless registered?
           raise PingNotAllowed,
           'System is not registered. Use the --regcode parameter to register it.'

--- a/lib/suse/connect/errors.rb
+++ b/lib/suse/connect/errors.rb
@@ -13,6 +13,7 @@ module SUSE
     class SystemNotRegisteredError < StandardError; end
     class BaseProductDeactivationError < StandardError; end
     class UnsupportedOperation < StandardError; end
+    class PingNotAllowed < StandardError; end
 
     # Basic error for API interactions. Collects HTTP response (which includes
     # status code and response body) for future showing to user via {Cli}

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 7 11:03:00 UTC 2022 - Natnael GEtahun <ngetahun@suse.com>
+
+- Add --keepalive command to send pings to SCC.
+
+-------------------------------------------------------------------
 Wed Oct 27 13:26:23 UTC 2021 - Thomas Schmidt <tschmidt@suse.com>
 
 - Update to 0.3.32

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -354,6 +354,13 @@ describe SUSE::Connect::Cli do
       expect { described_class.new(argv) }.to exit_with_code(0)
     end
 
+    xit 'sets keepalive option' do
+      argv = %w[--keepalive]
+      cli = described_class.new(argv)
+      expect(cli.option).to have_key :keepalive
+      expect(cli.option[:keepalive]).to exit_with_code(0)
+    end
+
     it 'outputs help on help flag with no line longer than 80 characters' do
       argv = %w[--help]
       expect_any_instance_of(described_class).to receive(:puts) do |option_parser|

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -241,12 +241,12 @@ describe SUSE::Connect::Cli do
         subject
       end
 
-      xcontext 'on unregistered system' do
+      context 'on unregistered system' do
         before { allow(SUSE::Connect::System).to receive(:credentials).and_return(nil) }
 
         it 'dies with error' do
-          expect(string_logger).to receive(:fatal).with(//)
-          expect { subject }.to exit_with_code(69)
+          expect(string_logger).to receive(:fatal).with(/Error sending keepalive: */)
+          expect { subject }.to exit_with_code(71)
         end
       end
     end

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -354,11 +354,11 @@ describe SUSE::Connect::Cli do
       expect { described_class.new(argv) }.to exit_with_code(0)
     end
 
-    xit 'sets keepalive option' do
+    it 'sets keepalive option' do
       argv = %w[--keepalive]
       cli = described_class.new(argv)
-      expect(cli.option).to have_key :keepalive
-      expect(cli.option[:keepalive]).to exit_with_code(0)
+      expect(cli.options).to have_key :keepalive
+      expect(cli.options[:keepalive]).to be_truthy
     end
 
     it 'outputs help on help flag with no line longer than 80 characters' do

--- a/spec/connect/cli_spec.rb
+++ b/spec/connect/cli_spec.rb
@@ -233,6 +233,25 @@ describe SUSE::Connect::Cli do
       end
     end
 
+    describe 'keepalive command' do
+      let(:opts) { %w[--keepalive] }
+
+      it '--keepalive calls keepalive! method' do
+        expect_any_instance_of(Client).to receive(:keepalive!)
+        subject
+      end
+
+      xcontext 'on unregistered system' do
+        before { allow(SUSE::Connect::System).to receive(:credentials).and_return(nil) }
+
+        it 'dies with error' do
+          expect(string_logger).to receive(:fatal).with(//)
+          expect { subject }.to exit_with_code(69)
+        end
+      end
+    end
+
+
     context 'cleanup command' do
       it '--cleanup calls Systems cleanup! method' do
         cli = described_class.new(%w[--cleanup])

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -723,6 +723,7 @@ describe SUSE::Connect::Client do
       before do
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with('/usr/sbin/registercloudguest').and_return(true)
+        allow(client_instance).to receive(:registered?).and_return true
       end
 
       context 'with no product' do
@@ -732,9 +733,12 @@ describe SUSE::Connect::Client do
       end
 
       context 'with product' do
-        before { allow_any_instance_of(Config).to receive(:product).and_return(true) }
+        before do
+          allow(client_instance).to receive(:deregister_product)
+          allow_any_instance_of(Config).to receive(:product).and_return(true)
+        end
 
-        it { expect { subject }.not_to raise_error(::SUSE::Connect::UnsupportedOperation) }
+        it { expect { subject }.not_to raise_error }
       end
     end
   end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -763,7 +763,7 @@ describe SUSE::Connect::Client do
     context 'when system is not registered' do
       before { allow(::SUSE::Connect::System).to receive(:credentials).and_return(nil) }
 
-      it { expect { subject }.to raise_error(::SUSE::Connect::UnsupportedOperation) }
+      it { expect { subject }.to raise_error(::SUSE::Connect::PingNotAllowed) }
     end
 
 
@@ -774,7 +774,7 @@ describe SUSE::Connect::Client do
       end
 
       it 'raises an error' do
-        expect { subject }.to raise_error(::SUSE::Connect::UnsupportedOperation)
+        expect { subject }.to raise_error(::SUSE::Connect::PingNotAllowed)
       end
     end
   end

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -765,18 +765,6 @@ describe SUSE::Connect::Client do
 
       it { expect { subject }.to raise_error(::SUSE::Connect::PingNotAllowed) }
     end
-
-
-    context 'when running on on-demand instance' do
-      before do
-        allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with('/usr/sbin/registercloudguest').and_return(true)
-      end
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(::SUSE::Connect::PingNotAllowed)
-      end
-    end
   end
 
   describe '#flatten_tree' do

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -735,7 +735,7 @@ describe SUSE::Connect::Client do
       context 'with product' do
         before do
           allow(client_instance).to receive(:deregister_product)
-          allow_any_instance_of(Config).to receive(:product).and_return(true)
+          allow(client_instance.config).to receive(:product).and_return(true)
         end
 
         it { expect { subject }.not_to raise_error }


### PR DESCRIPTION
## How to review

```bash
# build the sle15sp3 docker image
> docker build -t connect.15sp3 -f Dockerfile.15sp3 .

# Run the container
>docker run --privileged --network=host --rm -it connect.15sp3 bash

# Run the glue server in another terminal
> cd happy-customer/glue && bin/rails s

# Scenario 1: Un-registered system
# in the container, run
> bin/SUSEConnect --keepalive
# You should see an error message, directing you to register the container

# Scenario 2: Register system from regcodes in scc/glue
> bin/SUSEConnect -r xxxxx --url http://localhost....

> bin/SUSEConnect --keepalive

# Visit the glue web ui. Under the org > systems view, you should see the last_seen_at attribute updated

# Scenario 3: Simulate a pub-cloud machine
# On a registered system
> touch /usr/sbin/registercloudguest
> bin/SUSEConnect --keepalive

# You should see a success message.

```

Related trello card: https://trello.com/c/NFqpY5Vt/2272-uras-suseconnect-keepalive-subcommand