### PR TITLE
Implemented `System-Token` header sending

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -94,7 +94,7 @@ module SUSE
         end
 
 
-        log.info "\nSending data to SCC ..."
+        log.info "\nSending data to registration host #{@config.url} ..."
         @api.update_system(system_auth)
         log.info "Successfully updated the system\n".log_green.bold
       end

--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -264,9 +264,8 @@ module SUSE
           update_system
         else
           distro_target = @config.product ? @config.product.distro_target : nil
-          login, password = announce_system(distro_target,
-                                            @config.instance_data_file)
-          Credentials.new(login, password, Credentials.system_credentials_file).write
+          login, password = announce_system(distro_target, @config.instance_data_file)
+          Credentials.new(login, password, nil, Credentials.system_credentials_file).write
         end
       end
 

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.33'
+    VERSION = '0.3.34'
   end
 end

--- a/lib/suse/connect/yast.rb
+++ b/lib/suse/connect/yast.rb
@@ -108,7 +108,7 @@ module SUSE
         #
         # @return [Integer] number of written bytes
         def create_credentials_file(login, password, credentials_file = GLOBAL_CREDENTIALS_FILE)
-          Credentials.new(login, password, credentials_file).write
+          Credentials.new(login, password, nil, credentials_file).write
         end
 
         # Lists all available products for a system.

--- a/lib/suse/connect/zypper.rb
+++ b/lib/suse/connect/zypper.rb
@@ -178,7 +178,7 @@ module SUSE
         def write_service_credentials(service_name)
           login = System.credentials.username
           password = System.credentials.password
-          credentials = Credentials.new(login, password, service_name)
+          credentials = Credentials.new(login, password, nil, service_name)
           credentials.write
         end
 
@@ -192,7 +192,7 @@ module SUSE
         end
 
         def write_base_credentials(login, password)
-          credentials = Credentials.new(login, password, Credentials.system_credentials_file)
+          credentials = Credentials.new(login, password, nil, Credentials.system_credentials_file)
           credentials.write
         end
 

--- a/lib/suse/toolkit/utilities.rb
+++ b/lib/suse/toolkit/utilities.rb
@@ -4,6 +4,10 @@ module SUSE
     module Utilities
       include ::Net::HTTPHeader
 
+      # Response header that might be set as a response for a given request.
+      # This should, in turn, be saved into the credentials file.
+      SYSTEM_TOKEN_HEADER = 'System-Token'.freeze
+
       def token_auth(token)
         "Token token=#{token}"
       end
@@ -14,7 +18,7 @@ module SUSE
         password = system_credentials.password
 
         if username && password
-          basic_encode(username, password)
+          { encoded: basic_encode(username, password), token: system_credentials.system_token }
         else
           raise
         end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Mar 18 09:28:21 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
+
+- Update to 0.3.34
+- Manage the `System-Token` header. The `System-Token` header as delivered by
+  SCC will be stored inside of the credentials file for later use on API calls.
+  This way we add system clone detection for systems using this version of SUSE
+  Connect.
+
+-------------------------------------------------------------------
 Thu Feb 17 10:04:31 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 
 - Update to 0.3.33

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.33
+Version:        0.3.34
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/spec/connect/api_spec.rb
+++ b/spec/connect/api_spec.rb
@@ -23,6 +23,13 @@ describe SUSE::Connect::Api do
     end
   end
 
+  before do
+    # If the credentials file exists on the system it might try to read it
+    # after a request in order to update the `system_token` attribute. Skip
+    # this on the following tests.
+    allow(::SUSE::Connect::System).to receive(:credentials?).and_return(false)
+  end
+
   describe '#announce_system' do
     let(:payload) do
       [

--- a/spec/connect/credentials_spec.rb
+++ b/spec/connect/credentials_spec.rb
@@ -23,6 +23,7 @@ describe SUSE::Connect::Credentials do
       credentials = Credentials.read(file)
       expect(credentials.username).to eq 'SCC_f93f438773944ef087a30a37af7fc0a5'
       expect(credentials.password).to eq '231982b59ce961e38777c83685a5c42f'
+      expect(credentials.system_token).to be_nil
       expect(credentials.file).to eq file
     end
 
@@ -44,12 +45,25 @@ describe SUSE::Connect::Credentials do
       expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
       expect { Credentials.read(credentials_file) }.to raise_error(MalformedSccCredentialsFile, 'Cannot parse credentials file')
     end
+
+    it 'does not raise an error when the system_token cannot be parsed' do
+      allow_any_instance_of(String).to receive(:match).with(/^\s*username\s*=\s*(\S+)\s*$/).and_return(true)
+      allow_any_instance_of(String).to receive(:match).with(/^\s*password\s*=\s*(\S+)\s*$/).and_return(true)
+      allow_any_instance_of(String).to receive(:match).with(/^\s*system_token\s*=\s*(\S+)\s*$/).and_return(false)
+
+      expect(File).to receive(:exist?).and_return(true)
+      expect(File).to receive(:read).with(credentials_file).and_return("me\nfe")
+      creds = nil
+      expect { creds = Credentials.read(credentials_file) }.not_to raise_error
+
+      expect(creds.system_token).to be_nil
+    end
   end
 
   describe '#write' do
     it 'creates a credentials file accessible only by user' do
       Dir.mktmpdir do |dir|
-        credentials = Credentials.new('name', '1234', "#{dir}/SLES")
+        credentials = Credentials.new('name', '1234', nil, "#{dir}/SLES")
         expect { credentials.write }.not_to raise_error
         expect(File.size(credentials.file)).to be > 0
         expect(File.stat(credentials.file).mode).to eq 0100600
@@ -58,25 +72,26 @@ describe SUSE::Connect::Credentials do
 
     it 'compute filename to write properly --root case' do
       SUSE::Connect::System.filesystem_root = '/path/to/root'
-      credentials = Credentials.new('name', '1234', 'SLES')
+      credentials = Credentials.new('name', '1234', nil, 'SLES')
       expect(credentials.filename).to start_with '/path/to/root/'
       SUSE::Connect::System.filesystem_root = nil
     end
 
     it 'raises an error when file name is not set' do
-      credentials = Credentials.new('name', '1234', '')
+      credentials = Credentials.new('name', '1234', nil, '')
       expect { credentials.write }.to raise_error(RuntimeError)
-      credentials = Credentials.new('name', '1234', nil)
+      credentials = Credentials.new('name', '1234', nil, nil)
       expect { credentials.write }.to raise_error(RuntimeError)
     end
 
     it 'the written file can be read back' do
       Dir.mktmpdir do |dir|
-        credentials = Credentials.new('name', '1234', "#{dir}/SLES_credentials")
+        credentials = Credentials.new('name', '1234', 'whatever', "#{dir}/SLES_credentials")
         credentials.write
         read_credentials = Credentials.read(credentials.file)
         expect(read_credentials.username).to eq credentials.username
         expect(read_credentials.password).to eq credentials.password
+        expect(read_credentials.system_token).to eq credentials.system_token
         expect(read_credentials.file).to eq credentials.file
       end
     end
@@ -87,18 +102,21 @@ describe SUSE::Connect::Credentials do
       user = 'USER'
       file = 'FOO_credentials'
       password = '*eiW0yie2*'
-      credentials_str = Credentials.new(user, password, file).to_s
+      token = 'whatever'
+      credentials_str = Credentials.new(user, password, token, file).to_s
       expect(credentials_str).not_to include(password), 'The password is logged'
       expect(credentials_str).to include(user)
+      expect(credentials_str).to include(token)
       expect(credentials_str).to include(file)
     end
   end
 
   describe '#to_h' do
     it 'returns a hash representation of the object' do
-      hash = Credentials.new('USER', '*eiW0yie2*', 'FOO_credentials').to_h
+      hash = Credentials.new('USER', '*eiW0yie2*', 'whatever', 'FOO_credentials').to_h
       expect(hash.values).to include('USER')
       expect(hash.values).to include('*eiW0yie2*')
+      expect(hash.values).to include('whatever')
       expect(hash.values).to include('FOO_credentials')
     end
   end

--- a/spec/connect/system_spec.rb
+++ b/spec/connect/system_spec.rb
@@ -66,7 +66,7 @@ describe SUSE::Connect::System do
     end
 
     it 'returns true if credentials exist' do
-      allow(subject).to receive_messages(credentials: Credentials.new('123456789', 'ABCDEF'))
+      allow(subject).to receive_messages(credentials: Credentials.new('123456789', 'ABCDEF', 'suchtokensuchwow'))
       expect(subject.credentials?).to be true
     end
   end

--- a/spec/connect/yast_spec.rb
+++ b/spec/connect/yast_spec.rb
@@ -144,7 +144,7 @@ describe SUSE::Connect::YaST do
   describe '.credentials' do
     let(:login) { 'login' }
     let(:password) { 'password' }
-    let(:system_credentials) { Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE) }
+    let(:system_credentials) { Credentials.new(login, password, nil, subject::GLOBAL_CREDENTIALS_FILE) }
 
     context 'with no arguments' do
       it 'reads system credentials file' do
@@ -169,12 +169,12 @@ describe SUSE::Connect::YaST do
   describe '.create_credentials_file' do
     let(:login) { 'login' }
     let(:password) { 'password' }
-    let(:credentials) { Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE) }
+    let(:credentials) { Credentials.new(login, password, nil, subject::GLOBAL_CREDENTIALS_FILE) }
 
     it 'creates credentials file with default parameter' do
-      credentials = Credentials.new(login, password, subject::GLOBAL_CREDENTIALS_FILE)
+      credentials = Credentials.new(login, password, nil, subject::GLOBAL_CREDENTIALS_FILE)
 
-      expect(Credentials).to receive(:new).with(login, password, subject::GLOBAL_CREDENTIALS_FILE).and_return credentials
+      expect(Credentials).to receive(:new).with(login, password, nil, subject::GLOBAL_CREDENTIALS_FILE).and_return credentials
       expect(credentials).to receive(:write)
 
       subject.create_credentials_file(login, password)
@@ -182,9 +182,9 @@ describe SUSE::Connect::YaST do
 
     it 'creates credentials file with passed parameter' do
       credentials_file = '/tmp/Credentials'
-      credentials = Credentials.new(login, password, credentials_file)
+      credentials = Credentials.new(login, password, nil, credentials_file)
 
-      expect(Credentials).to receive(:new).with(login, password, credentials_file).and_return credentials
+      expect(Credentials).to receive(:new).with(login, password, nil, credentials_file).and_return credentials
       expect(credentials).to receive(:write)
 
       subject.create_credentials_file(login, password, credentials_file)

--- a/spec/connect/zypper_spec.rb
+++ b/spec/connect/zypper_spec.rb
@@ -470,7 +470,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'should call write_base_credentials_file' do
-      expect(Credentials).to receive(:new).with('dummy', 'tummy', Credentials::GLOBAL_CREDENTIALS_FILE).and_call_original
+      expect(Credentials).to receive(:new).with('dummy', 'tummy', nil, Credentials::GLOBAL_CREDENTIALS_FILE).and_call_original
       subject.write_base_credentials('dummy', 'tummy')
     end
   end
@@ -488,7 +488,7 @@ describe SUSE::Connect::Zypper do
     end
 
     it 'creates a file with source name' do
-      expect(Credentials).to receive(:new).with('dummy', 'tummy', 'turbo').and_call_original
+      expect(Credentials).to receive(:new).with('dummy', 'tummy', nil, 'turbo').and_call_original
       subject.write_service_credentials('turbo')
     end
   end

--- a/spec/support/credentials_mocks.rb
+++ b/spec/support/credentials_mocks.rb
@@ -13,7 +13,7 @@ def mock_dry_file
     allow(File).to receive(:open).and_return source_cred_file
     allow_any_instance_of(File).to receive(:puts).and_return true
     allow(Dir).to receive(:mkdir).and_return true
-    allow(SUSE::Connect::System).to receive(:credentials).and_return Credentials.new('dummy', 'tummy')
+    allow(SUSE::Connect::System).to receive(:credentials).and_return Credentials.new('dummy', 'tummy', 'yummy')
   end
 end
 

--- a/spec/toolkit/utilities_spec.rb
+++ b/spec/toolkit/utilities_spec.rb
@@ -20,9 +20,10 @@ describe SUSE::Toolkit::Utilities do
 
   describe '?basic_auth' do
     it 'returns string for auth header' do
-      allow(Credentials).to receive_messages(read: Credentials.new('bob', 'dylan'))
+      allow(Credentials).to receive_messages(read: Credentials.new('bob', 'dylan', 'zimmerman'))
       base64_line = 'Basic Ym9iOmR5bGFu'
-      expect(subject.send(:system_auth)).to eq base64_line
+      expect(subject.send(:system_auth)[:encoded]).to eq base64_line
+      expect(subject.send(:system_auth)[:token]).to eq 'zimmerman'
     end
 
     it 'raise if cannot get credentials' do
@@ -33,7 +34,7 @@ describe SUSE::Toolkit::Utilities do
     end
 
     it 'raise if nil credentials' do
-      allow(Credentials).to receive(:read).and_return(Credentials.new(nil, nil))
+      allow(Credentials).to receive(:read).and_return(Credentials.new(nil, nil, nil))
       expect { subject.send(:system_auth) }
         .to raise_error CannotBuildBasicAuth,
                         "\nCannot read username and password from #{SUSE::Connect::Credentials.system_credentials_file}. Please activate your system first."


### PR DESCRIPTION
## How to test

You want to check for cloned systems. Thus, one way to replicate the scenario is to simply use virtual machines and clone them as we are trying to prevent. For this, I'd follow these steps:

1. Create a first virtual machine with `SUSEConnect` installed (preferably with a version previous to this change).
2. Check that everything is working as usual for a local Glue instance.
3. Install the latest changes (either build your own package locally and pass it to the VM, or install it from `systemsmanagement:SCC/SUSEConnect`.
4. Check that not only everything is working as usual, but the server logged the presence of the system token, and `SUSEConnect` stores the token in the credentials file `/etc/zypp/credentials.d/SCCcredentials`.
5. Every interaction should refresh the token, with the proper logs from Glue.
6. *Clone* this VM. Now you should have two identical VMs.
7. From one VM perform another `SUSEConnect` command involving systems. Check that the token was indeed updated on the one that performed the command.
8. Go into the other VM and perform the same command: check that it has been detected as a clone (now, that's the juicy part 😋 )
9. You can reiterate on this by manually editing the credentials file from on VM and removing the system token altogether. With this, `SUSEConnect` will send an empty token, triggering point 4 on [this list](https://github.com/SUSE/happy-customer/blob/master/glue/app/controllers/api/base_controller.rb#L106-L111).

All in all, make sure that all the points described [here](https://github.com/SUSE/happy-customer/blob/master/glue/app/controllers/api/base_controller.rb#L106-L111) are actually tested.