### PR TITLE
Put regcode and OBS credentials to CI env vars

### DIFF
--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -4,6 +4,10 @@ ENV BUILT_AT "Mon May 8 16:53 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-standard &&\
     zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-12:/Update/standard/ SLE-12-update-standard &&\
     zypper ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-LTSS/x86_64/update/ SLE-12-ltss &&\
@@ -13,13 +17,14 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-stan
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-standard SLE-12-update-standard SLE-12-ltss
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --version '~> 1.17' --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -4,7 +4,9 @@ ENV BUILT_AT "Mon May 8 16:53 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -17,7 +19,9 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-stan
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-standard SLE-12-update-standard SLE-12-ltss
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -16,7 +16,7 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-stan
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-standard SLE-12-update-standard SLE-12-ltss
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -25,10 +25,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.12sp0
+++ b/Dockerfile.12sp0
@@ -4,9 +4,6 @@ ENV BUILT_AT "Mon May 8 16:53 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -18,9 +15,6 @@ RUN zypper ar http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/ SLE-12-stan
     zypper --non-interactive install --replacefiles git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-standard SLE-12-update-standard SLE-12-ltss
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -4,7 +4,9 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -20,7 +22,9 @@ RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP1-standard SLE-12-SP1-updates sle12sp1sdk sle12sp1sdk-updates
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -4,6 +4,10 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
     zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product/ SLE-12-SP1-standard &&\
     zypper ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/ SLE-12-SP1-updates &&\
@@ -16,13 +20,14 @@ RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP1-standard SLE-12-SP1-updates sle12sp1sdk sle12sp1sdk-updates
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --version '~> 1.17' --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -19,7 +19,7 @@ RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP1-standard SLE-12-SP1-updates sle12sp1sdk sle12sp1sdk-updates
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -28,10 +28,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.12sp1
+++ b/Dockerfile.12sp1
@@ -4,9 +4,6 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -21,9 +18,6 @@ RUN zypper --non-interactive --no-refresh rm container-suseconnect &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP1-standard SLE-12-SP1-updates sle12sp1sdk sle12sp1sdk-updates
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -4,7 +4,9 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -18,7 +20,9 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP2-standard SLE-12-SP2-updates sle12sp2sdk sle12sp2sdk-updates
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -4,6 +4,10 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP2/x86_64/product/ SLE-12-SP2-standard &&\
     zypper ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update/ SLE-12-SP2-updates &&\
     zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP2/x86_64/product/ sle12sp2sdk &&\
@@ -14,13 +18,14 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP2-standard SLE-12-SP2-updates sle12sp2sdk sle12sp2sdk-updates
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --version '~> 1.17' --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -17,7 +17,7 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP2-standard SLE-12-SP2-updates sle12sp2sdk sle12sp2sdk-updates
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -26,10 +26,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.12sp2
+++ b/Dockerfile.12sp2
@@ -4,9 +4,6 @@ ENV BUILT_AT "Tue May 9 14:46 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -19,9 +16,6 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP2-standard SLE-12-SP2-updates sle12sp2sdk sle12sp2sdk-updates
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -4,6 +4,10 @@ ENV BUILT_AT "Tue May 17 0:42 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/ SLE-12-SP3-standard &&\
     zypper ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/ SLE-12-SP3-updates &&\
     zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/ sle12sp3sdk &&\
@@ -14,13 +18,14 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP3-standard SLE-12-SP3-updates sle12sp3sdk sle12sp3sdk-updates
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --version '~> 1.17' --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -17,7 +17,7 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP3-standard SLE-12-SP3-updates sle12sp3sdk sle12sp3sdk-updates
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -26,10 +26,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -4,9 +4,6 @@ ENV BUILT_AT "Tue May 17 0:42 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -19,9 +16,6 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP3-standard SLE-12-SP3-updates sle12sp3sdk sle12sp3sdk-updates
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.12sp3
+++ b/Dockerfile.12sp3
@@ -4,7 +4,9 @@ ENV BUILT_AT "Tue May 17 0:42 CET 2017"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -18,7 +20,9 @@ RUN zypper --non-interactive ar http://download.suse.de/ibs/SUSE/Products/SLE-SE
       vim osc ruby2.1-rubygem-gem2rpm hwinfo libx86emu1 zypper-migration-plugin sudo curl && \
     zypper --non-interactive rr SLE-12-SP3-standard SLE-12-SP3-updates sle12sp3sdk sle12sp3sdk-updates
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.15sp0
+++ b/Dockerfile.15sp0
@@ -4,6 +4,10 @@ ENV BUILT_AT "Wed Feb 21 15:32 CET 2018"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 # Remember to drop docker caches if any of these change
 RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product base &&\
     zypper ar http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update base-updates &&\
@@ -14,13 +18,14 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk curl
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/Dockerfile.15sp0
+++ b/Dockerfile.15sp0
@@ -4,7 +4,9 @@ ENV BUILT_AT "Wed Feb 21 15:32 CET 2018"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -18,7 +20,9 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk curl
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.15sp0
+++ b/Dockerfile.15sp0
@@ -4,9 +4,6 @@ ENV BUILT_AT "Wed Feb 21 15:32 CET 2018"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -19,9 +16,6 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive up &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk curl
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.15sp0
+++ b/Dockerfile.15sp0
@@ -17,7 +17,7 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu1 zypper-migration-plugin sudo awk curl
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -26,10 +26,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.15sp3
+++ b/Dockerfile.15sp3
@@ -5,7 +5,9 @@ ENV BUILT_AT "Tue Jul 13 15:32 CET 2021"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG REGCODE
+ARG VALID_REGCODE
+ARG EXPIRED_REGCODE
+ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -20,7 +22,9 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl
 
-RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
+RUN sh /tmp/connect/integration/create_regcode.sh
+
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 

--- a/Dockerfile.15sp3
+++ b/Dockerfile.15sp3
@@ -5,9 +5,6 @@ ENV BUILT_AT "Tue Jul 13 15:32 CET 2021"
 
 RUN useradd --no-log-init --create-home scc
 
-ARG VALID_REGCODE
-ARG EXPIRED_REGCODE
-ARG NOT_ACTIVATED_REGCODE
 ARG OBS_USER
 ARG OBS_PASSWORD
 
@@ -21,9 +18,6 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive up &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl
-
-ADD integration/create_regcode.sh /tmp/connect/integration/create_regcode.sh
-RUN sh /tmp/connect/integration/create_regcode.sh
 
 ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh

--- a/Dockerfile.15sp3
+++ b/Dockerfile.15sp3
@@ -19,7 +19,7 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl
 
-ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+COPY integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
 RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
@@ -28,10 +28,10 @@ RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
 RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
-ADD Gemfile .
-ADD suse-connect.gemspec .
-ADD lib/suse/connect/version.rb ./lib/suse/connect/
+COPY Gemfile .
+COPY suse-connect.gemspec .
+COPY lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
-ADD . /tmp/connect
+COPY . /tmp/connect
 RUN chown -R scc /tmp/connect

--- a/Dockerfile.15sp3
+++ b/Dockerfile.15sp3
@@ -5,6 +5,10 @@ ENV BUILT_AT "Tue Jul 13 15:32 CET 2021"
 
 RUN useradd --no-log-init --create-home scc
 
+ARG REGCODE
+ARG OBS_USER
+ARG OBS_PASSWORD
+
 # Remember to drop docker caches if any of these change
 RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product base &&\
     zypper ar http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update base-updates &&\
@@ -16,13 +20,14 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN printf "$REGCODE" >> ~/.regcode
+ADD integration/create-oscrc.sh /tmp/connect/integration/create-oscrc.sh
+RUN sh /tmp/connect/integration/create-oscrc.sh
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --no-document
 
-RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
+RUN mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect
 
 ADD Gemfile .

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -29,27 +29,18 @@ def version_to_dot_notation(sp_notation)
   sp_notation.gsub(/_SP|-SP/, '.')
 end
 
-# This is ugly logic, but it is this way for compatibility with the existing code
-# If the TODOs are resolved, it can become simpler.
 def regcode_for_test(regcode_kind)
-  # Special case 1; shortcircuit all invalid
+  # Special case: shortcircuit all invalid
   return 'INVALID_REGCODE' if regcode_kind == 'INVALID' || regcode_kind.nil?
-
-  # Special case 2; regcode in environment for valid
-  return ENV['REGCODE'] if ENV['REGCODE'] && regcode_kind == 'VALID'
-
-  test_regcodes = YAML.load_file('/root/.regcode')
 
   regcode_key = case regcode_kind
                 when 'VALID'
-                  'code'
+                  'VALID_REGCODE'
                 when 'EXPIRED'
-                  'expired_code'
+                  'EXPIRED_REGCODE'
                 when 'NOTYETACTIVATED'
-                  'notyetactivated_code'
+                  'NOT_ACTIVATED_REGCODE'
                 end
 
-  regcode_key.prepend('beta_') if OPTIONS['beta']
-
-  test_regcodes[regcode_key] || "regcode file does not contain '#{regcode_key}'!!"
+  ENV.fetch(regcode_key)
 end

--- a/integration/create-oscrc.sh
+++ b/integration/create-oscrc.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -xe
+printf "[general]\n\
+build-root = /oscbuild/%(repo)s-%(arch)s\n\
+packagecachedir = /oscbuild/packagecache\n\
+[https://api.suse.de]\n\
+user=$OBS_USER\n\
+pass=$OBS_PASSWORD\n\
+sslcertck = 0\n\
+trusted_prj=SLE_12 SUSE:SLE-12:GA\n\
+[https://api.opensuse.org]\n\
+user=$OBS_USER\n\
+pass=$OBS_PASSWORD\n\
+sslcertck = 0\n\
+trusted_prj=SLE_12 SUSE:SLE-12:GA\n\
+" >> ~/.oscrc

--- a/integration/create-oscrc.sh
+++ b/integration/create-oscrc.sh
@@ -1,15 +1,16 @@
 #!/bin/sh -xe
-printf "[general]\n\
-build-root = /oscbuild/%(repo)s-%(arch)s\n\
-packagecachedir = /oscbuild/packagecache\n\
-[https://api.suse.de]\n\
-user=$OBS_USER\n\
-pass=$OBS_PASSWORD\n\
-sslcertck = 0\n\
-trusted_prj=SLE_12 SUSE:SLE-12:GA\n\
-[https://api.opensuse.org]\n\
-user=$OBS_USER\n\
-pass=$OBS_PASSWORD\n\
-sslcertck = 0\n\
-trusted_prj=SLE_12 SUSE:SLE-12:GA\n\
+echo -e "[general]\n
+build-root = /oscbuild/%(repo)s-%(arch)s\n
+packagecachedir = /oscbuild/packagecache\n
+[https://api.suse.de]\n
+user=$OBS_USER\n
+pass=$OBS_PASSWORD\n
+sslcertck = 0\n
+trusted_prj=SLE_12 SUSE:SLE-12:GA\n
+[https://api.opensuse.org]\n
+user=$OBS_USER\n
+pass=$OBS_PASSWORD\n
+sslcertck = 0\n
+trusted_prj=SLE_12 SUSE:SLE-12:GA\n
 " >> ~/.oscrc
+

--- a/integration/create_regcode.sh
+++ b/integration/create_regcode.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -xe
-
-printf "code:  $VALID_REGCODE\n\
-expired_code:  $EXPIRED_REGCODE\n\
-notyetactivated_code: $NOT_ACTIVATED_REGCODE
-" >> ~/.regcode

--- a/integration/create_regcode.sh
+++ b/integration/create_regcode.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -xe
+
+printf "code:  $VALID_REGCODE\n\
+expired_code:  $EXPIRED_REGCODE\n\
+notyetactivated_code: $NOT_ACTIVATED_REGCODE
+" >> ~/.regcode

--- a/prophet/.prophet_ci.yml
+++ b/prophet/.prophet_ci.yml
@@ -1,6 +1,6 @@
 projects:
   connect:
-    docker-build-image-sle12sp3: cd ..; docker build --build-arg REGCODE=$REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
-    docker-build-image-sle15sp0: cd ..; docker build --build-arg REGCODE=$REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
+    docker-build-image-sle12sp3: cd ..; docker build --build-arg VALID_REGCODE=$VALID_REGCODE  --build-arg EXPIRED_REGCODE=$EXPIRED_REGCODE  --build-arg NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
+    docker-build-image-sle15sp0: cd ..; docker build --build-arg VALID_REGCODE=$VALID_REGCODE  --build-arg EXPIRED_REGCODE=$EXPIRED_REGCODE  --build-arg NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
     docker-run-tests-sle12sp3: cd ..; docker run --privileged --rm -t connect.12sp3 ./docker/prophet_tests.sh
     docker-run-tests-sle15sp0: cd ..; docker run --privileged --rm -t connect.15sp0 ./docker/prophet_tests.sh

--- a/prophet/.prophet_ci.yml
+++ b/prophet/.prophet_ci.yml
@@ -1,6 +1,6 @@
 projects:
   connect:
-    docker-build-image-sle12sp3: cd ..; docker build -t connect.12sp3 -f Dockerfile.12sp3 .
-    docker-build-image-sle15sp0: cd ..; docker build -t connect.15sp0 -f Dockerfile.15sp0 .
+    docker-build-image-sle12sp3: cd ..; docker build --build-arg REGCODE=$REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
+    docker-build-image-sle15sp0: cd ..; docker build --build-arg REGCODE=$REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
     docker-run-tests-sle12sp3: cd ..; docker run --privileged --rm -t connect.12sp3 ./docker/prophet_tests.sh
     docker-run-tests-sle15sp0: cd ..; docker run --privileged --rm -t connect.15sp0 ./docker/prophet_tests.sh

--- a/prophet/.prophet_ci.yml
+++ b/prophet/.prophet_ci.yml
@@ -1,6 +1,6 @@
 projects:
   connect:
-    docker-build-image-sle12sp3: cd ..; docker build --build-arg VALID_REGCODE=$VALID_REGCODE  --build-arg EXPIRED_REGCODE=$EXPIRED_REGCODE  --build-arg NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
-    docker-build-image-sle15sp0: cd ..; docker build --build-arg VALID_REGCODE=$VALID_REGCODE  --build-arg EXPIRED_REGCODE=$EXPIRED_REGCODE  --build-arg NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
-    docker-run-tests-sle12sp3: cd ..; docker run --privileged --rm -t connect.12sp3 ./docker/prophet_tests.sh
-    docker-run-tests-sle15sp0: cd ..; docker run --privileged --rm -t connect.15sp0 ./docker/prophet_tests.sh
+    docker-build-image-sle12sp3: cd ..; docker build --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
+    docker-build-image-sle15sp0: cd ..; docker build --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
+    docker-run-tests-sle12sp3: cd ..; docker run -e VALID_REGCODE=$VALID_REGCODE -e EXPIRED_REGCODE=$EXPIRED_REGCODE -e NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --privileged --rm -t connect.12sp3 ./docker/prophet_tests.sh
+    docker-run-tests-sle15sp0: cd ..; docker run -e VALID_REGCODE=$VALID_REGCODE -e EXPIRED_REGCODE=$EXPIRED_REGCODE -e NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --privileged --rm -t connect.15sp0 ./docker/prophet_tests.sh


### PR DESCRIPTION
I did move the OBS credentials and CI Env vars to build and runtime aregs.

to test it locally, one can set those env vars and then (for example for SLES12SP3)

```
docker build --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.12sp3 -f Dockerfile.12sp3 .
docker run -e VALID_REGCODE=$VALID_REGCODE -e EXPIRED_REGCODE=$EXPIRED_REGCODE -e NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --privileged --rm -t connect.12sp3 ./docker/prophet_tests.sh
```

For SLES15

```
docker build --build-arg OBS_USER=$OBS_USER --build-arg OBS_PASSWORD=$OBS_PASSWORD -t connect.15sp0 -f Dockerfile.15sp0 .
docker run -e VALID_REGCODE=$VALID_REGCODE -e EXPIRED_REGCODE=$EXPIRED_REGCODE -e NOT_ACTIVATED_REGCODE=$NOT_ACTIVATED_REGCODE --privileged --rm -t connect.15sp0 ./docker/prophet_tests.sh
```