### PR TITLE
Remove the usage of the safe navigation operator

### DIFF
--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -102,7 +102,8 @@ module SUSE
       def update_system_token!(response)
         return unless System.credentials?
 
-        token = response.to_hash[SUSE::Toolkit::Utilities::SYSTEM_TOKEN_HEADER.downcase]&.first&.strip
+        value = response.to_hash[SUSE::Toolkit::Utilities::SYSTEM_TOKEN_HEADER.downcase]
+        token = value.first.strip unless value.nil? || value.first.nil?
         return if token.nil? || token.empty?
 
         creds = System.credentials


### PR DESCRIPTION
In some SLE systems that we support they do not have a ruby >= 2.3.0. Thus, this operator does not exist and a syntax error exception is thrown.