### PR TITLE
Add customer information when upgrading to inform about keepalive calls

### DIFF
--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -12,7 +12,8 @@ Thu Feb 17 10:04:31 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 
 - Update to 0.3.33
 - Add --keepalive command to send pings to SCC.
-- Add service/timer to periodically call --keepalive command (bsc#1196076)
+- Add service/timer to periodically call --keepalive command to make system
+  information in SCC and proxies more accurate. (bsc#1196076)
 
 -------------------------------------------------------------------
 Wed Oct 27 13:26:23 UTC 2021 - Thomas Schmidt <tschmidt@suse.com>

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -145,6 +145,50 @@ ln -sf service %{buildroot}%{_sbindir}/rcsuseconnect-keepalive
 %pre
 %service_add_pre suseconnect-keepalive.service suseconnect-keepalive.timer
 
+# Only run this part if SUSEConnect is being updated.
+# $1 holds the number of packages installed in this environment
+# see: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/
+if [ $1 -gt 1 ]; then
+  # in pre blocks the old version is still installed. This way we can determine
+  # the old version running.
+  version=$(SUSEConnect --version)
+  timer_release="0.3.33"
+
+  if printf "$version\n$timer_release" | sort -C -V ; then
+    cat << EOF
+Improving system visibility in the SUSE Customer Center 
+
+Getting a clear picture of how many systems are running SUSE products and
+consuming your subscriptions has not been an easy task. You might have physical
+and virtual systems running on-prem and others in the cloud, some systems are
+connected directly to SCC, while others sit behind RMT or are managed by SUSE
+Manager.
+
+The information shown in SCC is often incomplete or outdated, so it’s
+inconvenient to rely on it for renewal or compliance purposes.
+
+To help you overcome some of these challenges, we’ve been working on several
+improvements to our products, including SCC. For example, SUSE Manager (v4.1+)
+now sends system information to SCC, so that you can have a full picture of
+your system landscape. Additionally, SCC now captures which products are
+activated on systems that sit behind RMT or SMT.
+
+Another problem has been that the systems tracked in SCC are often not actually
+running anymore or have been decommissioned. To address this and to make it
+easier for you to spot those systems, this update will enable your system
+to “ping” SCC on a daily basis. You will then be able to easily filter
+out inactive systems and remove them from the SCC listing if necessary.
+
+(You can disable the daily ping if you don’t consider it necessary, by
+disabling the suseconnect-keepalive systemd timer).
+
+We will continue improving our products to make it easier for you to manage
+your systems and watch your subscription consumption. As always, we’d love to
+hear your feedback about these improvements and any ideas you might have.
+EOF
+  fi
+fi
+
 %post
 if [ -s /etc/zypp/credentials.d/NCCcredentials ] && [ ! -e /etc/zypp/credentials.d/SCCcredentials ]; then
     echo "Imported NCC system credentials to /etc/zypp/credentials.d/SCCcredentials"


### PR DESCRIPTION
card: https://trello.com/c/7t2H32jm/2338-uras-inform-customers-about-regular-keepalive-calls

This pull request adds an additional message to the output of rpm when `SUSEConnect` is updated.

**Note:** Now this uses the `%pre` hook to get the old SUSEConnect version. Please checkout `timer_version` which is the
version where the notable change was introduced.

## How to test this PR:
---

Built the package for different versions to test them. Good targets are `SLE_12_SP3` and `SLE_15_SP3`

```
$ = host system
> = docker container
# = comment
! = expectation

$pkgpath = Path to where the package is built in (probably: `/var/tmp/build-root/<sles version>-x86_64/home/abuild/rpmbuild/RPMS/x86_64/`)
```

```bash
## 1) When a customer upgrades from SUSEConnect <= 0.3.32 (which has no timer) to a version of SUSEConnect >= 0.3.33 (which has the timer), we want to display the notification.

# build the package for SLE_15_SP3 and prepare a connect container with SLE_15_SP3. Make sure the version of the built container is lower than 0.3.34 (which is the prs version).
$ cd $pkgpath
$ docker run -v (pwd):/connect --privileged --rm --network=host -h review-484 -ti connect.15sp3 /bin/bash
> cd /connect/
> zypper in SUSEConnect-0.3.34-0.x86_64.rpm
! This should print the upgrade message in rpm output

# 2) Upgrades after 0.3.34 should not show the message
# Rebuilt SUSEConnect but bump the version to 0.3.36 (to built a newer package) (keep the 0.3.34 somewhere safe rpmbuild will remove it!)
# Make sure you have both 0.3.34 and 0.3.36 SUSEConnect packages in $pkgpath
$ cd $pkgpath
$ docker run -v (pwd):/connect --privileged --rm --network=host -h review-484 -ti connect.15sp3 /bin/bash
> cd /connect
> zypper in SUSEConnect-0.3.34-0.x86_64.rpm
! This shows the message
> zypper in SUSEConnect-0.3.36-0.x86_64.rpm
! This does not show the message

# 3) New install does not show the message
$ cd $pkgpath
$ docker run -v (pwd):/connect --privileged --rm --network=host -h foo -ti opensuse/leap:15.3 /bin/bash
$ cd /connect
$ zypper in SUSEConnect-0.3.34-0.x86_64.rpm
! This should not show the message!
```

If there are any questions, please do not hesitate to message me! :rocket: 