### PR TITLE
Manually randomize timer execution time on SLES 12 systems.

### DIFF
--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -202,6 +202,15 @@ if update-alternatives --config SUSEConnect  &> /dev/null ; then
   ln -fs ../sbin/%{name} %{_bindir}/%{name}
 fi
 
+# Randomize shedule times for SLES12. SLES12 systemd does not support
+# RandomizedDelaySec=24h.
+%if (0%{?sle_version} > 0 && 0%{?sle_version} < 150000)
+    TIMER_HOUR=$(( RANDOM % 24 ))
+    TIMER_MINUTE=$(( RANDOM % 60 ))
+
+    sed -i '/RandomizedDelaySec*/d' %{_unitdir}/suseconnect-keepalive.timer
+    sed -i "s/OnCalendar=daily/OnCalendar=*-*-* $TIMER_HOUR:$TIMER_MINUTE:00/" %{_unitdir}/suseconnect-keepalive.timer
+%endif
 %service_add_post suseconnect-keepalive.service suseconnect-keepalive.timer
 
 %preun


### PR DESCRIPTION
card: https://trello.com/c/teVXUvbs/2384-bug-sle12-suseconnect-unknown-lvalue-randomizeddelaysec-in-section-timer

Replace `RandomDelaySec` in SLE 12 systems since systemd does not support this feature yet.

**How to test this change:**
```
# Prepare:
$ rake package:build_gem
$ mktemp /tmp/connect-test
$ osc co systemsmanagement:SCC SUSEConnect -o /tmp/connect-test/
$ cp -r package/* /tmp/connect-test/
$ pushd /tmp/connect-test
$ osc addremove

# SLE 15 SP3
$ osc build --no-verify SLE_15_SP3
$ docker run -v /var/tmp/build-root/SLE_15_SP3-x86_64/home/abuild/rpmbuild/RPMS/x86_64:/rpm --privileged --rm --network=host -h test-timer -ti connect.15sp3 /bin/bash
> zypper in /rpm/SUSEConnect-0.3.34-0.x86_64.rpm
> cat /usr/lib/systemd/system/suseconnect-keepalive.timer
#! The timer should show the RandomDelaySec and onCalendar=daily
> systemctl list-timers --all
#! Check the timer is recognized and ready to go

# SLE 12 SP2
# SLES12 needs a running virtual maschine since systemd is not available in containers
# I go with vagrant:
$ osc build --no-verify SLE_12_SP5
$ cp /var/tmp/build-root/SLE_12_SP5-x86_64/home/abuild/rpmbuild/RPMS/x86_64/SUSEConnect-0.3.34-0.x86_64.rpm .
$  vagrant box add sles12sp5 https://download.suse.de/ibs/Virtualization:/Vagrant:/SLE-12-SP5/images/SLES12-SP5-Vagrant.x86_64-libvirt.box
$ vagrant init sles12sp5
$ vagrant up --provider=libvirt
$ vagrant ssh 
> sudo su
> zypper in /vagrant/SUSEConnect-0.3.34-0.x86_64.rpm
> cat /usr/lib/systemd/system/suseconnect-keepalive.timer
#! The timer is randomized and only uses OnCalendar and not RandomDelaySec
> systemctl list-timers --all
#! Check that the timer is recognized and ready to go.
> zypper remove SUSEConnect
> zypper in /vagrant/SUSEConnect-0.3.34-0.x86_64.rpm
> systemctl list-timers --all
#! Scheduled time must change here!
```