### PR TITLE
Remove timer activation in postinstall

### DIFF
--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.34'
+    VERSION = '0.3.35'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,4 +1,10 @@
--------------------------------------------------------------------
+--------------------------------------------------------------------
+Mon Jul 4 10:00:00 UTC 2022 - Natnael Getahun <ngetahun@suse.com>
+
+- Update to 0.3.35
+- Remove automatic enablement of sync timer. (bsc#1200641)
+
+------------------------------------------------------------------
 Fri Mar 18 09:28:21 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 
 - Update to 0.3.34

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -2,7 +2,8 @@
 Mon Jul 4 10:00:00 UTC 2022 - Natnael Getahun <ngetahun@suse.com>
 
 - Update to 0.3.35
-- Remove automatic enablement of sync timer. (bsc#1200641)
+- Rely on system-wide defaults for enabling the keepalive timer by systemd-presets-branding-SLE. (bsc#1200641)
+
 
 ------------------------------------------------------------------
 Fri Mar 18 09:28:21 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.34
+Version:        0.3.35
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -219,15 +219,6 @@ fi
 %postun
 %service_del_postun suseconnect-keepalive.service suseconnect-keepalive.timer
 
-%posttrans
-# Force the enablement and the restart of the SUSEConnect --keepalive timer.
-if [ -x "$(command -v systemctl)" ]; then
-    if [ "$(/usr/bin/systemctl is-enabled suseconnect-keepalive.timer)" != "enabled" ]; then
-        /usr/bin/systemctl enable suseconnect-keepalive.timer
-    fi
-    /usr/bin/systemctl restart suseconnect-keepalive.timer
-fi
-
 %files
 %defattr(-,root,root,-)
 %{_sbindir}/SUSEConnect


### PR DESCRIPTION
## Description
This PR removes the post install script to enable sync timer.

## How to test
We need to build the package and run it in a container (bci container from registry)

Steps
--------

```bash
# in connect repo dir
> gem build suse-connect.gemspec 
# copy to osc build dir
> cp package/* <path to suse connect obs dir>
> cp suse-connect*.gem <path to suse connect obs dir>
# move to obs directory
> osc build SLE_15 x86_64 -k /tmp/connect_build/ --no-verify

# run container and include tmp volume
> docker run --rm -ti -v /tmp/connect_build/:/tmp/connect_build registry.suse.com/bci/bci-base:15.3 

# install connect without any errors
> zypper -n rm container-suseconnect && zypper in -y ruby2.5 dmidecode update-alternatives net-tools

> rpm -i /tmp/connect_build/SUSEConnect-0.3.35-0.x86_64.rpm 
```
