### PR TITLE
Fail gracefully in containerized arm environment that don't have systemd-detect-virt installed .

### DIFF
--- a/lib/suse/connect/hwinfo/arm64.rb
+++ b/lib/suse/connect/hwinfo/arm64.rb
@@ -24,6 +24,8 @@ class SUSE::Connect::HwInfo::ARM64 < SUSE::Connect::HwInfo::Base
     def hypervisor
       vendor = execute('systemd-detect-virt -v', false, [0, 1])
       vendor == 'none' ? nil : vendor
+    rescue SUSE::Connect::SystemCallError, Errno::ENOENT
+      nil
     end
 
     def uuid


### PR DESCRIPTION
Reference: https://trello.com/c/XM17tI5X/1171-suseconnect-missing-systemd-dependency-for-aarch64