### PR TITLE
Write services with ssl_verify=no when using connect with insecure

### DIFF
--- a/lib/suse/connect/client.rb
+++ b/lib/suse/connect/client.rb
@@ -42,6 +42,15 @@ module SUSE
         service = activate_product(product, @config.email)
 
         log.info '-> Adding service to system ...'
+
+        if @config.insecure
+          uri = URI.parse(service.url)
+          params = URI.decode_www_form(uri.query || '') + [[:ssl_verify, 'no']]
+          uri.query = URI.encode_www_form(params)
+
+          service.url = uri.to_s
+        end
+
         System.add_service(service, !@config.no_zypper_refs)
         if install_release_package
           log.info '-> Installing release package ...'

--- a/spec/connect/client_spec.rb
+++ b/spec/connect/client_spec.rb
@@ -395,7 +395,7 @@ describe SUSE::Connect::Client do
   end
 
   describe '#register_product' do
-    let(:service_stub) { 'service_stub' }
+    let(:service_stub) { OpenStruct.new(url: 'http://service.local/') }
     let(:fake_email) { 'email@email.org.what.ever' }
 
     before do
@@ -459,6 +459,28 @@ describe SUSE::Connect::Client do
           expect(Zypper).not_to receive(:install_release_package)
 
           subject.register_product(product, false)
+        end
+      end
+    end
+
+    context 'handling insecure' do
+      let(:config) do
+        SUSE::Connect::Config.new.merge!({ 'insecure' => true })
+      end
+
+      before do
+        allow(SUSE::Connect::Config).to receive(:new).and_return(config)
+      end
+
+      context 'when insecure true' do
+        it 'adds ssl_verify=no to the service url' do
+          expect(subject).to receive(:activate_product).with(product, fake_email).and_return service_stub
+          expect(System).to receive(:add_service).with(service_stub, true)
+
+          expect(Zypper).to receive(:install_release_package).with(product.identifier)
+
+          subject.register_product(product)
+          expect(service_stub.url).to include('ssl_verify=no')
         end
       end
     end


### PR DESCRIPTION
When configuring /etc/SUSEConnect with `insecure: true` SUSEConnect
will now write `ssl_verify=no` into the service files, this will
allow zypper to skip ssl verification just exactly as SUSEConnect
does.