### PR TITLE
Fixed a couple of bugs on the systemd service for keepalive

### DIFF
--- a/features/version.feature
+++ b/features/version.feature
@@ -5,5 +5,5 @@ Feature: Version output
   Scenario: if version param is passed alone
     Given I run `SUSEConnect --version`
     Then the exit status should be 0
-    And the output should match /^\d{1,2}\.\d{1,2}\.\d{1,2}$/
+    And the output should match /^\d{1,2}\.\d{1,2}(\.\d{1,2})?$/
     And the output should contain exactly current version number

--- a/lib/suse/connect/connection.rb
+++ b/lib/suse/connect/connection.rb
@@ -28,6 +28,7 @@ module SUSE
           proxy_port = http.proxy_uri.port
           proxy_user = SUSE::Toolkit::CurlrcDotfile.new.username
           proxy_pass = SUSE::Toolkit::CurlrcDotfile.new.password
+          log.debug("Using proxy: #{http.proxy_uri}")
           http = Net::HTTP.new(uri.host, uri.port, proxy_address, proxy_port, proxy_user, proxy_pass)
         end
         http.use_ssl     = uri.is_a? URI::HTTPS

--- a/lib/suse/connect/version.rb
+++ b/lib/suse/connect/version.rb
@@ -1,5 +1,5 @@
 module SUSE
   module Connect
-    VERSION = '0.3.35'
+    VERSION = '0.4'
   end
 end

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -4,6 +4,7 @@ Wed Jul 27 14:08:54 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 - Update to 0.4
 - Allow suseconnect-keepalive.service to recognize a configured proxy. (bsc#1200994)
 - Remove the `WantedBy` statement from suseconnect-keepalive.service since it's only to be triggered by a systemd timer.
+- SUSEConnect will now ensure that the `PROXY_ENABLED` environment variable is honored.
 
 --------------------------------------------------------------------
 Mon Jul 4 10:00:00 UTC 2022 - Natnael Getahun <ngetahun@suse.com>

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -3,6 +3,7 @@ Wed Jul 27 14:08:54 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 
 - Update to 0.4
 - Allow suseconnect-keepalive.service to recognize a configured proxy. (bsc#1200994)
+- Remove the `WantedBy` statement from suseconnect-keepalive.service since it's only to be triggered by a systemd timer.
 
 --------------------------------------------------------------------
 Mon Jul 4 10:00:00 UTC 2022 - Natnael Getahun <ngetahun@suse.com>

--- a/package/SUSEConnect.changes
+++ b/package/SUSEConnect.changes
@@ -1,3 +1,9 @@
+-------------------------------------------------------------------
+Wed Jul 27 14:08:54 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
+
+- Update to 0.4
+- Allow suseconnect-keepalive.service to recognize a configured proxy. (bsc#1200994)
+
 --------------------------------------------------------------------
 Mon Jul 4 10:00:00 UTC 2022 - Natnael Getahun <ngetahun@suse.com>
 

--- a/package/SUSEConnect.spec
+++ b/package/SUSEConnect.spec
@@ -17,7 +17,7 @@
 
 
 Name:           SUSEConnect
-Version:        0.3.35
+Version:        0.4
 Release:        0
 %define mod_name suse-connect
 %define mod_full_name %{mod_name}-%{version}

--- a/package/suseconnect-keepalive.service
+++ b/package/suseconnect-keepalive.service
@@ -5,6 +5,7 @@ Wants=suseconnect-keepalive.timer
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/SUSEConnect --keepalive
+EnvironmentFile=-/etc/sysconfig/proxy
 
 # Filter out this special exit code, since it will be raised by `SUSEConnect
 # --keepalive` whenever a system is not registered, which is a pretty typical

--- a/package/suseconnect-keepalive.service
+++ b/package/suseconnect-keepalive.service
@@ -11,6 +11,3 @@ EnvironmentFile=-/etc/sysconfig/proxy
 # --keepalive` whenever a system is not registered, which is a pretty typical
 # scenario.
 SuccessExitStatus=71
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
## Description

There were two issues reported against the systemd unit for the keepalive service. Namely:

1. A customer told us that the keepalive service was ignoring a configured proxy. Proxies use the `/etc/sysconfig/proxy` file, and so the provided `.service` file from our package must include it as an optional environment file. The first commit fixes this.
2. The service file required the `multi-user` target, which would tell systemd to run this service whenever a new shell user is set up. This was not wanted either, so I have removed it on the second commit.

With these two updates, I have updated the version of `SUSEConnect` to `0.4` according to the new versioning scheme that we have discussed internally.

## How to test

The easiest way to reproduce [bsc#1200994](https://bugzilla.suse.com/show_bug.cgi?id=1200994) is a bit tricky. In my case I started a VM with SLE 15 SP4 (it cannot be a docker container because we need systemd in order to test this, but it can also be a random host you have). Then:

1. Install the latest SUSEConnect from OBS and apply my patch (just copy-paste the `.service` file).
2. Run `systemd daemon-reload`.
3. Register the machine as usual.
4. Run `systemctl start suseconnect-keepalive.service` and check that it works as usual.
5. Apply the configuration you can find in the related bug for `/etc/sysconfig/proxy`.
6. Run `systemctl start suseconnect-keepalive.service` again and check that it doesn't work (because you do not have access to the proxy as given on that configuration).
7. Run `systemctl status suseconnect-keepalive.service` just to check that it failed because it tried to reach that unreachable proxy. This is proof enough that it picks the values from that file.

## Related bugs

Fixes [bsc#1200994](https://bugzilla.suse.com/show_bug.cgi?id=1200994).