### PR TITLE
Fix CI for SLES 15 SP3

### DIFF
--- a/features/step_definition/library_steps.rb
+++ b/features/step_definition/library_steps.rb
@@ -4,7 +4,7 @@ end
 
 When(/^I should receive the next Service Packs as online migration targets$/) do
   products = SUSE::Connect::Status.new(@client.config).system_products.map(&:to_openstruct)
-  migration_targets = @client.system_migrations(products, kind: :online).flatten.uniq.map(&:shortname)
+  migration_targets = @client.system_migrations(products, kind: :online).flatten.map(&:shortname).uniq
   expect(migration_targets).to match_array(OPTIONS['online_migration_targets'])
 end
 

--- a/features/support/environments.yml
+++ b/features/support/environments.yml
@@ -4,6 +4,7 @@ SLE_15_SP3:
   online_migration_targets:
   - "Basesystem-Module"
   - "SLES15-SP4"
+  - "SLES15-SP5"
   - "Server-Applications-Module"
   next_version: SLES15-SP4
   base_product:
@@ -28,17 +29,11 @@ SLE_15:
   beta: true
   online_migration_targets:
   - "Basesystem-Module"
-  - "Basesystem-Module"
-  - "Basesystem-Module"
   - "Python2-Module"
-  - "Python2-Module"
-  - "Python2-Module"
+  - "Server-Applications-Module"
   - "SLES15-SP1"
   - "SLES15-SP2"
   - "SLES15-SP3"
-  - "Server-Applications-Module"
-  - "Server-Applications-Module"
-  - "Server-Applications-Module"
   next_version: SLES15-SP1
   base_product:
     repositories:


### PR DESCRIPTION
CI is broken since feature tests does not expect `SLES 15 SP5` as possible migration target.

**How to test this change:**
There is nothing to be tested manually. CI needs to be green.