### PR TITLE
Don't write an empty token to the service credentials file

### DIFF
--- a/lib/suse/connect/credentials.rb
+++ b/lib/suse/connect/credentials.rb
@@ -96,8 +96,12 @@ module SUSE
       end
 
       # serialize the credentials for writing to a file
+      # don't serialize the token when it is nil, because it's an unknown
+      # attribute for zypp in the service credentials
       def serialize
-        "username=#{username}\npassword=#{password}\nsystem_token=#{system_token}\n"
+        content = "username=#{username}\npassword=#{password}\n"
+        content += "system_token=#{system_token}\n" if system_token
+        content
       end
     end
   end


### PR DESCRIPTION
How to reproduce: 

Register a system, and see no empty `system_token=` like in `/etc/zypp/credentials.d/Basesystem_Module_x86_64` for example.