### PR TITLE
No need to register the base system

### DIFF
--- a/features/localization.feature
+++ b/features/localization.feature
@@ -1,19 +1,9 @@
 @slow_process
 Feature: Test localized server responses
-
-  Scenario: Register base system
-    Given I have a system with activated base product
-
   Scenario: API response language check
     Given I set the environment variables to:
       | variable | value |
       | LANG     | de    |
 
     When I call SUSEConnect with '--regcode INVALID' arguments
-    Then the exit status should be 67
-
-    And the output should contain "Keine Subscription mit diesem Registrierungscode gefunden"
-
-
-  Scenario: Remove all registration leftovers
-    Then I deregister the system
+    Then the output should contain "Unbekannter Registrierungscode"


### PR DESCRIPTION
To test that the server returns a localized message, there's no need to register the system, which just takes time. We can simply try to register with an invalid regcode.

Fixes https://ci.suse.de/blue/organizations/jenkins/scc-connect-ng-prs/detail/set-registry-credentials/3/pipeline/#step-48-log-1956